### PR TITLE
feat: add Tidal as a lossless music source

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -732,6 +732,27 @@ val SpotifyAccountAvatarUrlKey = stringPreferencesKey("spotify_account_avatar_ur
 val ShowSpotifyPlaylistsKey = booleanPreferencesKey("show_spotify_playlists")
 val SpotifyLibraryPlaylistsCacheKey = stringPreferencesKey("spotify_library_playlists_cache")
 
+// Tidal music source integration (ported from MetroFuse)
+val TidalCookieKey = stringPreferencesKey("tidalCookie")
+val TidalEnabledKey = booleanPreferencesKey("tidalEnabled")
+val TidalAudioQualityKey = stringPreferencesKey("tidalAudioQuality")
+val TidalArtworkFallbackEnabledKey = booleanPreferencesKey("tidalArtworkFallbackEnabled")
+val TidalAnimatedCoversEnabledKey = booleanPreferencesKey("tidalAnimatedCoversEnabled")
+val TidalAccountNameKey = stringPreferencesKey("tidal_account_name")
+
+enum class TidalAudioQuality {
+    AAC_320,
+    FLAC,
+    HI_RES_LOSSLESS,
+}
+
+val TidalAudioQualityOptions =
+    listOf(
+        TidalAudioQuality.AAC_320,
+        TidalAudioQuality.FLAC,
+        TidalAudioQuality.HI_RES_LOSSLESS,
+    )
+
 val WebClientPoTokenEnabledKey = booleanPreferencesKey("webClientPoTokenEnabled")
 val PoTokenGvsKey = stringPreferencesKey("poTokenGvs")
 val PoTokenPlayerKey = stringPreferencesKey("poTokenPlayer")

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -172,6 +172,10 @@ import moe.rukamori.archivetune.constants.PermanentShuffleKey
 import moe.rukamori.archivetune.constants.PersistentQueueKey
 import moe.rukamori.archivetune.constants.PlayerStreamClient
 import moe.rukamori.archivetune.constants.PlayerStreamClientKey
+import moe.rukamori.archivetune.constants.TidalAudioQuality
+import moe.rukamori.archivetune.constants.TidalAudioQualityKey
+import moe.rukamori.archivetune.constants.TidalEnabledKey
+import moe.rukamori.archivetune.tidal.TidalAudioProvider
 import moe.rukamori.archivetune.constants.PlayerVolumeKey
 import moe.rukamori.archivetune.constants.RepeatModeKey
 import moe.rukamori.archivetune.constants.ScrobbleDelayPercentKey
@@ -6909,6 +6913,78 @@ class MusicService :
         }
     }
 
+    private fun parseTidalAudioQuality(): TidalAudioQuality {
+        val stored = dataStore.get(TidalAudioQualityKey, TidalAudioQuality.FLAC.name)
+        return runCatching { TidalAudioQuality.valueOf(stored) }.getOrDefault(TidalAudioQuality.FLAC)
+    }
+
+    /**
+     * Attempts to resolve the current media item as a Tidal stream. Returns a [DataSpec]
+     * pointing at a Tidal (FLAC/Hi-Res) stream when the Tidal source is enabled and a match
+     * is found; otherwise returns null so playback falls through to the YouTube resolver.
+     *
+     * Ported from MetroFuse's multi-provider audio pipeline, adapted to ArchiveTune's
+     * single-seam [resolvePlaybackDataSpec] resolver.
+     */
+    private fun resolveTidalDataSpec(
+        dataSpec: DataSpec,
+        mediaId: String,
+    ): DataSpec? {
+        if (!dataStore.get(TidalEnabledKey, false)) return null
+        if (mediaId.isLocalMediaId()) return null
+
+        val song =
+            runCatching {
+                runBlocking(Dispatchers.IO) { database.song(mediaId).first() }
+            }.getOrNull()
+
+        val queuedMetadata = currentMediaMetadata.value?.takeIf { it.id == mediaId }
+        val title =
+            song?.song?.title
+                ?: queuedMetadata?.title
+                ?: return null
+        val artists =
+            song?.artists?.map { it.name }?.takeIf { it.isNotEmpty() }
+                ?: queuedMetadata?.artists?.map { it.name }.orEmpty()
+        val album =
+            song?.song?.albumName
+                ?: song?.album?.title
+                ?: queuedMetadata?.album?.title
+        val durationMs =
+            song?.song?.duration
+                ?.takeIf { it > 0 }
+                ?.toLong()
+                ?.times(1000L)
+                ?: queuedMetadata?.duration?.takeIf { it > 0 }?.toLong()?.times(1000L)
+
+        val query =
+            TidalAudioProvider.Query(
+                mediaId = mediaId,
+                title = title,
+                artists = artists,
+                album = album,
+                isrc = null,
+                durationMs = durationMs,
+            )
+
+        val resolved =
+            runCatching {
+                TidalAudioProvider.resolve(
+                    query = query,
+                    cacheDir = cacheDir,
+                    preferAtmos = false,
+                    preferLiveDash = false,
+                    audioQuality = parseTidalAudioQuality(),
+                )
+            }.onFailure { error ->
+                Timber.tag("MusicService").w(error, "TIDAL stream resolution failed for %s", mediaId)
+            }.getOrNull() ?: return null
+
+        Timber.tag("MusicService").i("Using TIDAL stream for %s: %s", mediaId, resolved.label)
+        resolved.contentLength?.takeIf { it > 0L }?.let { contentLengthCache[mediaId] = it }
+        return dataSpec.withUri(resolved.mediaUri.toUri())
+    }
+
     private fun resolvePlaybackDataSpec(
         dataSpec: DataSpec,
         allowCacheShortCircuit: Boolean,
@@ -6965,6 +7041,12 @@ class MusicService :
                 scope.launch(Dispatchers.IO) { recoverSong(mediaId) }
                 return dataSpec
             }
+        }
+
+        // Tidal music source: attempt to resolve a lossless Tidal stream before YouTube.
+        resolveTidalDataSpec(dataSpec, mediaId)?.let { tidalDataSpec ->
+            scope.launch(Dispatchers.IO) { recoverSong(mediaId) }
+            return tidalDataSpec
         }
 
         val lowDataModeActive = isLowDataModeActive()

--- a/app/src/main/kotlin/moe/rukamori/archivetune/tidal/TidalAudioProvider.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/tidal/TidalAudioProvider.kt
@@ -1,0 +1,2060 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package moe.rukamori.archivetune.tidal
+
+import android.net.Uri
+import android.util.Base64
+import moe.rukamori.archivetune.constants.TidalAudioQuality
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONArray
+import org.json.JSONObject
+import timber.log.Timber
+import java.text.Normalizer
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.io.File
+import java.io.OutputStream
+import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+import kotlin.math.abs
+import kotlin.math.roundToInt
+
+object TidalAudioProvider {
+    private const val API_BASE_URL = "https://tidal.com/v1"
+    private const val SONG_LINK_API_URL = "https://api.song.link/v1-alpha.1/links"
+    private const val PUBLIC_TOKEN = "49YxDN9a2aFV6RTG"
+    private const val COUNTRY_CODE = "US"
+    private const val LOCALE = "en_US"
+    private const val DEVICE_TYPE = "BROWSER"
+    private const val DOWNLOAD_USER_AGENT = "ArchiveTune-Android"
+    private const val BROWSER_USER_AGENT =
+        "Mozilla/5.0 (Linux; Android 14; Pixel 8 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Mobile Safari/537.36"
+    private const val DASH_MIME_TYPE = "application/dash+xml"
+    private const val AUDIO_MP4_MIME_TYPE = "audio/mp4"
+    private const val AUDIO_FLAC_MIME_TYPE = "audio/flac"
+    private const val MP4_BOX_HEADER_SIZE = 8
+    private const val MP4_EXTENDED_BOX_HEADER_SIZE = 16
+    private const val STREAM_CACHE_MS = 45 * 60 * 1000L
+    private const val TRACK_CACHE_MS = 60 * 60 * 1000L
+    private const val STREAM_FAILURE_CACHE_MS = 15 * 60 * 1000L
+    private const val TRACK_STREAM_FAILURE_CACHE_MS = 60 * 60 * 1000L
+    private const val TEMP_FILE_MAX_AGE_MS = 6 * 60 * 60 * 1000L
+    private const val RATE_LIMIT_COOLDOWN_MS = 8 * 60 * 1000L
+    private const val SEARCH_LIMIT = 8
+    private const val SEARCH_CACHE_MS = 10 * 60 * 1000L
+    private const val MAX_STREAM_CANDIDATES = 2
+    private const val MAX_DIRECT_STREAM_CANDIDATES = 3
+    private const val MIN_MATCH_SCORE = 90
+    private const val STRONG_MATCH_SCORE = 150
+    private const val REJECT_SCORE = -1_000_000
+    private val AMAZON_DATE = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'", Locale.US)
+    private val DOWNLOAD_API_ENDPOINTS =
+        listOf(
+            TidalDownloadEndpoint("HiFi is Back v2.7", "https://hifi-isback.peridotclient.com"),
+            TidalDownloadEndpoint("Maus QQDL v2.6", "https://maus.qqdl.site"),
+            TidalDownloadEndpoint("Vogel QQDL v2.6", "https://vogel.qqdl.site"),
+            TidalDownloadEndpoint("Katze QQDL v2.6", "https://katze.qqdl.site"),
+            TidalDownloadEndpoint("Hund QQDL v2.6", "https://hund.qqdl.site"),
+            TidalDownloadEndpoint("Wolf QQDL v2.6", "https://wolf.qqdl.site"),
+        )
+
+    data class Query(
+        val mediaId: String,
+        val title: String,
+        val artists: List<String>,
+        val album: String?,
+        val isrc: String?,
+        val durationMs: Long?,
+    )
+
+    data class Resolved(
+        val mediaUri: String,
+        val trackId: String,
+        val label: String,
+        val mimeType: String,
+        val codecs: String,
+        val bitrate: Int,
+        val sampleRate: Int?,
+        val contentLength: Long?,
+        val expiresAtMs: Long,
+        val losslessDowngradedBitrateKbps: Int? = null,
+        val isLiveManifest: Boolean = false,
+    )
+
+    data class CandidateMetadata(
+        val trackId: String,
+        val title: String,
+        val artist: String,
+        val album: String?,
+        val isrc: String?,
+        val durationMs: Long?,
+    )
+
+    open class TidalAudioResolutionException(message: String, cause: Throwable? = null) : Exception(message, cause)
+
+    class TidalRateLimitedException(
+        val retryAfterMs: Long,
+    ) : TidalAudioResolutionException("TIDAL FLAC resolver is rate limited; cooling down for ${retryAfterMs / 1000L}s")
+
+    private data class CachedTrack(
+        val track: MatchedTrack,
+        val expiresAtMs: Long,
+    )
+
+    private data class CachedFailure(
+        val message: String,
+        val expiresAtMs: Long,
+    )
+
+    private data class CachedSearch(
+        val results: JSONArray,
+        val expiresAtMs: Long,
+    )
+
+    private data class MatchedTrack(
+        val trackId: String,
+        val title: String,
+        val artistNames: List<String>,
+        val album: String?,
+        val isrc: String?,
+        val durationMs: Long?,
+        val audioQuality: String?,
+        val mediaTags: Set<String>,
+        val audioModes: Set<String>,
+        val sampleRate: Int?,
+    ) {
+        fun supportsLossless(): Boolean =
+            qualitySignals().any { signal ->
+                signal.contains("LOSSLESS", ignoreCase = true) ||
+                    signal.contains("FLAC", ignoreCase = true)
+            }
+
+        fun supportsHiResLossless(): Boolean =
+            qualitySignals().any { signal ->
+                signal.contains("HI_RES", ignoreCase = true) ||
+                    signal.contains("HIRES", ignoreCase = true) ||
+                    signal.contains("MAX", ignoreCase = true)
+            }
+
+        fun supportsAtmos(): Boolean =
+            qualitySignals().any { signal ->
+                signal.contains("DOLBY_ATMOS", ignoreCase = true) ||
+                    signal.contains("DOLBY ATMOS", ignoreCase = true) ||
+                    signal.contains("EAC3_JOC", ignoreCase = true) ||
+                    signal.contains("ATMOS", ignoreCase = true)
+            }
+
+        fun losslessRank(): Int =
+            when {
+                supportsHiResLossless() -> 3
+                supportsLossless() -> 2
+                supportsAtmos() -> 1
+                else -> 0
+            }
+
+        fun qualityScoreBoost(): Int =
+            when {
+                supportsHiResLossless() -> 70
+                supportsLossless() -> 55
+                supportsAtmos() -> 20
+                else -> 0
+            }
+
+        private fun qualitySignals(): List<String> =
+            buildList {
+                audioQuality?.takeIf { it.isNotBlank() }?.let(::add)
+                addAll(mediaTags)
+                addAll(audioModes)
+            }
+    }
+
+    private data class ParsedManifest(
+        val url: String,
+        val mimeType: String,
+        val codecs: String,
+        val sampleRate: Int?,
+        val bitrate: Int?,
+        val expiryUrl: String?,
+        val isDash: Boolean,
+        val segmentUrls: List<String> = emptyList(),
+        val outputExtension: String = ".flac",
+        val manifestText: String? = null,
+    )
+
+    private data class StreamMetadata(
+        val mimeType: String?,
+        val contentLength: Long?,
+    )
+
+    private data class PlaybackStreamInfo(
+        val mimeType: String,
+        val codecs: String,
+        val contentLength: Long?,
+    )
+
+    private class TidalDownloadEndpoint(
+        val name: String,
+        baseUrl: String,
+    ) {
+        val baseUrl: String = baseUrl.trimEnd('/')
+    }
+
+    private data class ScoredTrack(
+        val track: MatchedTrack,
+        val score: Int,
+    )
+
+    private val client =
+        OkHttpClient
+            .Builder()
+            .connectTimeout(8, TimeUnit.SECONDS)
+            .readTimeout(20, TimeUnit.SECONDS)
+            .callTimeout(25, TimeUnit.SECONDS)
+            .build()
+
+    private val trackCache = ConcurrentHashMap<String, CachedTrack>()
+    private val searchCache = ConcurrentHashMap<String, CachedSearch>()
+    private val streamCache = ConcurrentHashMap<String, Resolved>()
+    private val streamFailureCache = ConcurrentHashMap<String, CachedFailure>()
+
+    @Volatile
+    private var resolverRateLimitedUntilMs = 0L
+
+    fun resolve(
+        query: Query,
+        cacheDir: File? = null,
+        preferAtmos: Boolean = false,
+        preferLiveDash: Boolean = true,
+        audioQuality: TidalAudioQuality = TidalAudioQuality.AAC_320,
+    ): Resolved {
+        val now = System.currentTimeMillis()
+        val cooldownRemainingMs = resolverRateLimitedUntilMs - now
+        if (cooldownRemainingMs > 0L) {
+            throw TidalRateLimitedException(cooldownRemainingMs)
+        }
+        cacheDir?.let(::cleanupTempFiles)
+        val directTrackId = query.mediaId.toTidalTrackIdOrNull()
+        val trackCacheKey = query.trackCacheKey()
+        val tracks = if (directTrackId != null) {
+            val directTrack = resolveTrackById(directTrackId) ?: query.toDirectMatchedTrack(directTrackId)
+            buildList {
+                add(directTrack)
+                findCandidateTracks(query)
+                    .asSequence()
+                    .filterNot { it.trackId == directTrack.trackId }
+                    .take(MAX_DIRECT_STREAM_CANDIDATES - 1)
+                    .forEach { add(it) }
+            }.distinctBy { it.trackId }
+        } else {
+            val cached =
+                trackCache[trackCacheKey]
+                ?.takeIf { it.expiresAtMs > now }
+                ?.track
+            val candidates = findCandidateTracks(query)
+            buildList {
+                addAll(candidates)
+                cached?.let(::add)
+            }.distinctBy { it.trackId }
+        }
+
+        if (tracks.isEmpty()) {
+            throw TidalAudioResolutionException("TIDAL match not found for ${query.title}")
+        }
+
+        val errors = mutableListOf<String>()
+        var deferredAacFallback: Resolved? = null
+        val streamCandidateLimit =
+            if (directTrackId != null) MAX_DIRECT_STREAM_CANDIDATES else MAX_STREAM_CANDIDATES
+        for (track in tracks.take(streamCandidateLimit)) {
+            for (quality in streamQualityCandidates(track, preferAtmos, audioQuality)) {
+                val streamCacheKey = "${query.mediaId}::${track.trackId}::$quality::${if (preferLiveDash) "live" else "temp"}"
+                val trackFailureCacheKey = "track:${track.trackId}::$quality::${if (preferLiveDash) "live" else "temp"}"
+                val cachedStream = streamCache[streamCacheKey]
+                    ?.takeIf { it.expiresAtMs > now + 20_000L }
+                if (cachedStream != null) {
+                    if (cachedStream.losslessDowngradedBitrateKbps == null) {
+                        return cachedStream
+                    }
+                    deferredAacFallback = deferredAacFallback ?: cachedStream
+                    errors += "${track.trackId}/$quality: cached AAC fallback"
+                    continue
+                }
+
+                val cachedFailure = cachedFailureFor(now, streamCacheKey, trackFailureCacheKey)
+                if (cachedFailure != null) {
+                    errors += "${track.trackId}/$quality: cached resolver failure: ${cachedFailure.message}"
+                    continue
+                }
+
+                val streamAttempt = runCatching {
+                    requestDirectFlac(
+                        track = track,
+                        quality = quality,
+                        durationMs = query.durationMs ?: track.durationMs,
+                        now = now,
+                        cacheDir = cacheDir,
+                        preferLiveDash = preferLiveDash,
+                        audioQuality = audioQuality,
+                    )
+                }.onFailure { error ->
+                    Timber.tag("TidalAudio").w(error, "TIDAL $quality stream failed for ${track.trackId}")
+                    errors += "${track.trackId}/$quality: ${error.message ?: error.javaClass.simpleName}"
+                    cacheStreamFailure(now, error, streamCacheKey, trackFailureCacheKey)
+                }
+
+                streamAttempt.getOrNull()?.let { resolved ->
+                    streamCache[streamCacheKey] = resolved
+                    if (directTrackId == null) {
+                        trackCache[trackCacheKey] = CachedTrack(track, now + TRACK_CACHE_MS)
+                    }
+                    if (resolved.losslessDowngradedBitrateKbps == null) {
+                        return resolved
+                    }
+                    deferredAacFallback = deferredAacFallback ?: resolved
+                    errors += "${track.trackId}/$quality: returned AAC fallback"
+                }
+            }
+        }
+
+        deferredAacFallback?.let { return it }
+
+        throw TidalAudioResolutionException(
+            "TIDAL FLAC stream not found for ${query.title}: ${errors.joinToString("; ").take(720)}",
+        )
+    }
+
+    fun invalidate(mediaId: String) {
+        val prefix = "$mediaId::"
+        for (key in streamCache.keys) {
+            if (key.startsWith(prefix)) {
+                streamCache.remove(key)?.mediaUri?.deleteIfLocalFileUri()
+            }
+        }
+        for (key in streamFailureCache.keys) {
+            if (key.startsWith(prefix)) {
+                streamFailureCache.remove(key)
+            }
+        }
+        trackCache.remove(mediaId.trackCacheKeyFallback())
+    }
+
+    private fun cachedFailureFor(
+        now: Long,
+        vararg keys: String,
+    ): CachedFailure? {
+        for (key in keys.distinct()) {
+            val failure = streamFailureCache[key] ?: continue
+            if (failure.expiresAtMs > now) return failure
+            streamFailureCache.remove(key)
+        }
+        return null
+    }
+
+    private fun cacheStreamFailure(
+        now: Long,
+        error: Throwable,
+        vararg keys: String,
+    ) {
+        val message = error.message ?: error.javaClass.simpleName
+        val expiresAtMs = now + error.streamFailureCacheDurationMs()
+        keys
+            .distinct()
+            .forEach { key ->
+                streamFailureCache[key] = CachedFailure(
+                    message = message,
+                    expiresAtMs = expiresAtMs,
+                )
+            }
+    }
+
+    private fun Throwable.streamFailureCacheDurationMs(): Long =
+        when {
+            this is TidalRateLimitedException || causeChainContains("rate limited") -> RATE_LIMIT_COOLDOWN_MS
+            causeChainContains("did not return FLAC") || causeChainContains("downgraded") -> TRACK_STREAM_FAILURE_CACHE_MS
+            else -> STREAM_FAILURE_CACHE_MS
+        }
+
+    private fun Throwable.causeChainContains(text: String): Boolean {
+        var current: Throwable? = this
+        while (current != null) {
+            if (current.message?.contains(text, ignoreCase = true) == true) return true
+            current = current.cause
+        }
+        return false
+    }
+
+    fun isTidalTrackId(value: String): Boolean = value.toTidalTrackIdOrNull() != null
+
+    fun searchCandidates(
+        query: Query,
+        limit: Int = 8,
+    ): List<CandidateMetadata> =
+        findCandidateTracks(query)
+            .take(limit.coerceAtLeast(1))
+            .map { track ->
+                CandidateMetadata(
+                    trackId = track.trackId,
+                    title = track.title,
+                    artist = track.artistNames.joinToString(", "),
+                    album = track.album,
+                    isrc = track.isrc,
+                    durationMs = track.durationMs,
+                )
+            }
+
+    fun isLiveManifestUri(value: String?): Boolean =
+        value
+            ?.let(Uri::parse)
+            ?.path
+            ?.replace('\\', '/')
+            ?.let { path ->
+                path.contains("/tidal-temp/") && path.endsWith(".mpd", ignoreCase = true)
+            } == true
+
+    fun normalizeIsrc(value: String?): String? {
+        val compact = value
+            ?.uppercase(Locale.US)
+            ?.replace(Regex("[^A-Z0-9]"), "")
+            ?: return null
+        return Regex("[A-Z]{2}[A-Z0-9]{3}[0-9]{7}")
+            .find(compact)
+            ?.value
+    }
+
+    private fun findCandidateTracks(query: Query): List<MatchedTrack> {
+        val candidates = mutableListOf<ScoredTrack>()
+        val wantedTitle = query.title.titleMatchNormalized()
+        val wantedArtists = query.artists.map { it.normalized() }.filter { it.isNotBlank() }
+        val wantedAlbum = query.album.normalized()
+        val wantedIsrc = normalizeIsrc(query.isrc)
+        val wantedDurationMs = query.durationMs?.takeIf { it > 0L }
+        normalizeIsrc(query.isrc)?.let { isrc ->
+            searchTracks(isrc, exactIsrc = true)
+                ?.let { selectCandidateTracks(it, query, exactIsrcOnly = true) }
+                ?.losslessFirst()
+                ?.firstOrNull()
+                ?.takeIf { it.score >= MIN_MATCH_SCORE }
+                ?.let { return listOf(it.track) }
+        }
+
+        val terms = searchTerms(query)
+        for (term in terms) {
+            val results = searchTracks(term) ?: continue
+            candidates += selectCandidateTracks(results, query)
+            candidates.losslessFirst()
+                .firstOrNull()
+                ?.takeIf { it.score >= STRONG_MATCH_SCORE && it.track.losslessRank() > 0 }
+                ?.let { return listOf(it.track) }
+        }
+        resolveSongLinkTidalTrackId(query)?.let { tidalId ->
+            val track = resolveTrackById(tidalId) ?: query.toDirectMatchedTrack(tidalId)
+            val score = scoreTrack(track, wantedTitle, wantedArtists, wantedAlbum, wantedIsrc, wantedDurationMs)
+            if (score >= MIN_MATCH_SCORE) {
+                if (track.losslessRank() > 0) {
+                    return listOf(track)
+                }
+                candidates += ScoredTrack(track, score)
+                Timber.tag("TidalAudio").w("Deferred lossy song.link TIDAL match $tidalId for ${query.title}: score=$score")
+            } else {
+                Timber.tag("TidalAudio").w("Ignored weak song.link TIDAL match $tidalId for ${query.title}: score=$score")
+            }
+        }
+        return candidates
+            .groupBy { it.track.trackId }
+            .mapNotNull { (_, matches) -> matches.maxByOrNull { it.score } }
+            .losslessFirst()
+            .map { it.track }
+    }
+
+    private fun searchTracks(
+        term: String,
+        exactIsrc: Boolean = false,
+    ): JSONArray? {
+        if (term.isBlank()) return null
+        searchTracksFromDirectApi(term, exactIsrc)?.takeIf { it.length() > 0 }?.let { return it }
+        return searchTracksFromTidalApi(term)
+    }
+
+    private fun searchTracksFromDirectApi(
+        term: String,
+        exactIsrc: Boolean,
+    ): JSONArray? {
+        val cacheKey = "direct:${if (exactIsrc) "isrc" else "query"}:${term.lowercase(Locale.US)}"
+        val now = System.currentTimeMillis()
+        searchCache[cacheKey]?.takeIf { it.expiresAtMs > now }?.let { return it.results }
+        val parameter = if (exactIsrc) "i" else "s"
+        for (endpoint in DOWNLOAD_API_ENDPOINTS) {
+            val url =
+                endpoint.baseUrl
+                    .toHttpUrl()
+                    .newBuilder()
+                    .addPathSegment("search")
+                    .addQueryParameter(parameter, term)
+                    .addQueryParameter("limit", SEARCH_LIMIT.toString())
+                    .addQueryParameter("offset", "0")
+                    .build()
+            val request =
+                Request
+                    .Builder()
+                    .url(url)
+                    .get()
+                    .header("Accept", "application/json")
+                    .header("User-Agent", DOWNLOAD_USER_AGENT)
+                    .build()
+
+            runCatching {
+                client.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) return@use null
+                    val body = response.body.string().takeIf { it.isNotBlank() } ?: return@use null
+                    val root = JSONObject(body)
+                    root.optJSONObject("data")?.optJSONArray("items")
+                        ?: root.optJSONArray("items")
+                }
+            }.getOrNull()?.let { results ->
+                searchCache[cacheKey] = CachedSearch(results, now + SEARCH_CACHE_MS)
+                return results
+            }
+        }
+        return null
+    }
+
+    private fun searchTracksFromTidalApi(term: String): JSONArray? {
+        val url =
+            "$API_BASE_URL/search/tracks"
+                .toHttpUrl()
+                .newBuilder()
+                .addQueryParameter("countryCode", COUNTRY_CODE)
+                .addQueryParameter("locale", LOCALE)
+                .addQueryParameter("deviceType", DEVICE_TYPE)
+                .addQueryParameter("query", term)
+                .addQueryParameter("limit", SEARCH_LIMIT.toString())
+                .addQueryParameter("offset", "0")
+                .build()
+        val request =
+            Request
+                .Builder()
+                .url(url)
+                .get()
+                .header("Accept", "application/json")
+                .header("User-Agent", BROWSER_USER_AGENT)
+                .header("x-tidal-token", PUBLIC_TOKEN)
+                .build()
+
+        return runCatching {
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) return@use null
+                val body = response.body.string().takeIf { it.isNotBlank() } ?: return@use null
+                JSONObject(body).optJSONArray("items")
+            }
+        }.getOrNull()
+    }
+
+    private fun resolveTrackById(trackId: String): MatchedTrack? {
+        val url =
+            "$API_BASE_URL/tracks/$trackId"
+                .toHttpUrl()
+                .newBuilder()
+                .addQueryParameter("countryCode", COUNTRY_CODE)
+                .addQueryParameter("locale", LOCALE)
+                .addQueryParameter("deviceType", DEVICE_TYPE)
+                .build()
+        val request =
+            Request
+                .Builder()
+                .url(url)
+                .get()
+                .header("Accept", "application/json")
+                .header("User-Agent", BROWSER_USER_AGENT)
+                .header("x-tidal-token", PUBLIC_TOKEN)
+                .build()
+
+        return runCatching {
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) return@use null
+                val body = response.body.string().takeIf { it.isNotBlank() } ?: return@use null
+                JSONObject(body).toMatchedTrack()
+            }
+        }.getOrNull()
+    }
+
+    private fun selectCandidateTracks(
+        results: JSONArray,
+        query: Query,
+        exactIsrcOnly: Boolean = false,
+    ): List<ScoredTrack> {
+        val wantedTitle = query.title.titleMatchNormalized()
+        val wantedArtists = query.artists.map { it.normalized() }.filter { it.isNotBlank() }
+        val wantedAlbum = query.album.normalized()
+        val wantedIsrc = normalizeIsrc(query.isrc)
+        val wantedDurationMs = query.durationMs?.takeIf { it > 0L }
+        val candidates = mutableListOf<ScoredTrack>()
+        for (index in 0 until results.length()) {
+            val obj = results.optJSONObject(index) ?: continue
+            val track = obj.toMatchedTrack() ?: continue
+            if (exactIsrcOnly && normalizeIsrc(track.isrc) != wantedIsrc) continue
+            val score = scoreTrack(track, wantedTitle, wantedArtists, wantedAlbum, wantedIsrc, wantedDurationMs)
+            if (score >= MIN_MATCH_SCORE) {
+                candidates += ScoredTrack(track, score)
+            }
+        }
+        return candidates.losslessFirst()
+    }
+
+    private fun List<ScoredTrack>.losslessFirst(): List<ScoredTrack> =
+        sortedWith(
+            compareByDescending<ScoredTrack> { it.track.losslessRank() }
+                .thenByDescending { it.score },
+        )
+
+    private fun scoreTrack(
+        track: MatchedTrack,
+        wantedTitle: String,
+        wantedArtists: List<String>,
+        wantedAlbum: String,
+        wantedIsrc: String?,
+        wantedDurationMs: Long?,
+    ): Int {
+        val candidateTitle = track.title.titleMatchNormalized()
+        val candidateArtists = track.artistNames.map { it.normalized() }.filter { it.isNotBlank() }
+        val candidateAlbum = track.album.normalized()
+        val candidateIsrc = normalizeIsrc(track.isrc)
+
+        if (wantedTitle.isBlank() || candidateTitle.isBlank()) return REJECT_SCORE
+        if (wantedIsrc != null && candidateIsrc == wantedIsrc) {
+            return if (durationMatches(wantedDurationMs, track.durationMs)) {
+                220 + track.qualityScoreBoost()
+            } else {
+                REJECT_SCORE
+            }
+        }
+        if (hasVersionMismatch(wantedTitle, candidateTitle)) return REJECT_SCORE
+
+        val wantedTitleTokens = significantTokens(wantedTitle)
+        val candidateTitleTokens = significantTokens(candidateTitle)
+        var score = 0
+        when {
+            candidateTitle == wantedTitle -> score += 110
+            candidateTitle.contains(wantedTitle) || wantedTitle.contains(candidateTitle) -> score += 62
+            else -> {
+                val titleOverlap = tokenOverlap(wantedTitleTokens, candidateTitleTokens)
+                if (titleOverlap < 0.50) return REJECT_SCORE
+                score += (titleOverlap * 48).roundToInt()
+            }
+        }
+        val extraCandidateTitleTokens = candidateTitleTokens - wantedTitleTokens
+        score -= (extraCandidateTitleTokens.size * 6).coerceAtMost(24)
+
+        if (wantedArtists.isNotEmpty() && candidateArtists.isNotEmpty()) {
+            val artistHit = wantedArtists.any { wanted ->
+                candidateArtists.any { candidate ->
+                    candidate == wanted || candidate.contains(wanted) || wanted.contains(candidate)
+                }
+            }
+            if (artistHit) {
+                score += 38
+            } else {
+                return REJECT_SCORE
+            }
+        }
+
+        if (wantedAlbum.isNotBlank() && candidateAlbum.isNotBlank()) {
+            score += when {
+                candidateAlbum == wantedAlbum -> 18
+                candidateAlbum.contains(wantedAlbum) || wantedAlbum.contains(candidateAlbum) -> 10
+                else -> 0
+            }
+        }
+
+        if (wantedIsrc != null) {
+            score += when {
+                candidateIsrc == wantedIsrc -> 160
+                candidateIsrc != null -> -30
+                else -> 0
+            }
+        }
+
+        val candidateDurationMs = track.durationMs
+        if (wantedDurationMs != null && candidateDurationMs != null) {
+            val diffSeconds = abs(wantedDurationMs - candidateDurationMs) / 1000L
+            if (diffSeconds > 45) return REJECT_SCORE
+            score += when {
+                diffSeconds <= 3 -> 36
+                diffSeconds <= 8 -> 18
+                diffSeconds <= 20 -> 4
+                else -> -50
+            }
+        }
+
+        score += track.qualityScoreBoost()
+
+        return score
+    }
+
+    private fun requestDirectFlac(
+        track: MatchedTrack,
+        quality: String,
+        durationMs: Long?,
+        now: Long,
+        cacheDir: File?,
+        preferLiveDash: Boolean,
+        audioQuality: TidalAudioQuality,
+    ): Resolved {
+        val isAtmosRequest = quality.equals("DOLBY_ATMOS", ignoreCase = true)
+        val manifestFormats = quality.tidalManifestFormats()
+        val errors = mutableListOf<String>()
+        var rateLimitCount = 0
+        var longestRetryAfterMs = 0L
+        for (endpoint in DOWNLOAD_API_ENDPOINTS) {
+            val result =
+                runCatching {
+                    requestDirectFlacFromEndpoint(
+                        endpoint = endpoint,
+                        isAtmosRequest = isAtmosRequest,
+                        manifestFormats = manifestFormats,
+                        track = track,
+                        quality = quality,
+                        durationMs = durationMs,
+                        now = now,
+                        cacheDir = cacheDir,
+                        preferLiveDash = preferLiveDash,
+                        audioQuality = audioQuality,
+                    )
+                }
+            result.getOrNull()?.let { return it }
+            val error = result.exceptionOrNull() ?: continue
+            if (error is TidalRateLimitedException) {
+                rateLimitCount += 1
+                longestRetryAfterMs = maxOf(longestRetryAfterMs, error.retryAfterMs)
+            }
+            errors += "${endpoint.name}: ${error.message ?: error.javaClass.simpleName}"
+            Timber.tag("TidalAudio").w(error, "TIDAL resolver ${endpoint.name} failed for ${track.trackId}")
+        }
+        if (rateLimitCount == DOWNLOAD_API_ENDPOINTS.size && longestRetryAfterMs > 0L) {
+            resolverRateLimitedUntilMs = System.currentTimeMillis() + longestRetryAfterMs
+            throw TidalRateLimitedException(longestRetryAfterMs)
+        }
+        throw TidalAudioResolutionException(
+            "TIDAL resolver failed on all mirrors for ${track.title}: ${errors.joinToString(" | ").take(720)}",
+        )
+    }
+
+    private fun requestDirectFlacFromEndpoint(
+        endpoint: TidalDownloadEndpoint,
+        isAtmosRequest: Boolean,
+        manifestFormats: List<String>?,
+        track: MatchedTrack,
+        quality: String,
+        durationMs: Long?,
+        now: Long,
+        cacheDir: File?,
+        preferLiveDash: Boolean,
+        audioQuality: TidalAudioQuality,
+    ): Resolved {
+        val url = if (manifestFormats != null) {
+            endpoint.baseUrl
+                .toHttpUrl()
+                .newBuilder()
+                .addPathSegment("trackManifests")
+                .addQueryParameter("id", track.trackId)
+                .apply {
+                    manifestFormats.forEach { format ->
+                        addQueryParameter("formats", format)
+                    }
+                }
+                .addQueryParameter("adaptive", "false")
+                .addQueryParameter("manifestType", "MPEG_DASH")
+                .addQueryParameter("uriScheme", "HTTPS")
+                .addQueryParameter("usage", "PLAYBACK")
+                .build()
+        } else {
+            endpoint.baseUrl
+                .toHttpUrl()
+                .newBuilder()
+                .addPathSegment("track")
+                .addQueryParameter("id", track.trackId)
+                .addQueryParameter("quality", quality)
+                .build()
+        }
+        val request =
+            Request
+                .Builder()
+                .url(url)
+                .get()
+                .header("Accept", "application/json")
+                .header("User-Agent", DOWNLOAD_USER_AGENT)
+                .build()
+
+        client.newCall(request).execute().use { response ->
+            val responseBody = response.body.string()
+            if (response.code == 429) {
+                val headerRetryAfterMs = response.header("Retry-After")
+                    ?.toLongOrNull()
+                    ?.times(1000L)
+                    ?.coerceAtLeast(60_000L)
+                val bodyRetryAfterMs = runCatching {
+                    JSONObject(responseBody)
+                        .optLong("retry_after")
+                        .takeIf { it > 0L }
+                        ?.times(1000L)
+                }.getOrNull()
+                val retryAfterMs = headerRetryAfterMs
+                    ?: bodyRetryAfterMs
+                    ?: RATE_LIMIT_COOLDOWN_MS
+                throw TidalRateLimitedException(retryAfterMs)
+            }
+            if (!response.isSuccessful) {
+                throw TidalAudioResolutionException(
+                    "TIDAL ${endpoint.name} HTTP ${response.code}: ${responseBody.take(180)}",
+                )
+            }
+            val root = JSONObject(responseBody)
+            val data = root.optJSONObject("data")
+                ?: throw TidalAudioResolutionException("TIDAL FLAC resolver returned no data")
+            val effectiveDurationMs = durationMs ?: track.durationMs
+            val resolvedQuality: String
+            val manifest: ParsedManifest
+            val dataSampleRate: Int?
+            val dataBitDepth: Int?
+            if (manifestFormats != null) {
+                val attributes = data
+                    .optJSONObject("data")
+                    ?.optJSONObject("attributes")
+                    ?: throw TidalAudioResolutionException("TIDAL manifest payload missing attributes")
+                val formats = attributes.optJSONArray("formats")
+                val returnedFormats =
+                    formats
+                        ?.let { array ->
+                            (0 until array.length())
+                                .mapNotNull { index -> array.optString(index).takeIf(String::isNotBlank) }
+                        }
+                        .orEmpty()
+                if (returnedFormats.none { returned -> manifestFormats.any { it.equals(returned, ignoreCase = true) } }) {
+                    throw TidalAudioResolutionException("TIDAL API did not report ${manifestFormats.joinToString()} for this track")
+                }
+                val manifestUrl = attributes.stringOrNull("uri")
+                    ?: throw TidalAudioResolutionException("TIDAL manifest URI was empty")
+                val manifestText = fetchText(manifestUrl)
+                manifest = parseManifestText(manifestText, "audio/mp4")
+                resolvedQuality = returnedFormats.toResolvedTidalQuality(quality)
+                dataSampleRate = manifest.sampleRate ?: 48_000
+                dataBitDepth = null
+            } else {
+                if (data.optString("assetPresentation").equals("PREVIEW", ignoreCase = true)) {
+                    throw TidalAudioResolutionException("TIDAL FLAC resolver returned a preview asset")
+                }
+                val manifestPayload = data.stringOrNull("manifest")
+                    ?: throw TidalAudioResolutionException("TIDAL FLAC resolver returned no manifest")
+                resolvedQuality = data.stringOrNull("audioQuality") ?: quality
+                manifest = parseManifest(manifestPayload, data.stringOrNull("manifestMimeType"), effectiveDurationMs)
+                dataSampleRate = normalizeSampleRate(data.doubleOrNull("sampleRate"))
+                dataBitDepth = data.longOrNull("bitDepth")?.toInt()
+            }
+            val manifestDeclaresFlac =
+                manifest.mimeType.contains("flac", ignoreCase = true) ||
+                    manifest.codecs.contains("flac", ignoreCase = true)
+            val manifestLooksFlac =
+                manifestDeclaresFlac
+            val isAtmosManifest =
+                isAtmosRequest ||
+                    resolvedQuality.contains("ATMOS", ignoreCase = true) ||
+                    manifest.codecs.contains("eac3", ignoreCase = true) ||
+                    manifest.codecs.contains("ec-3", ignoreCase = true)
+            val returnedHiRes =
+                resolvedQuality.contains("HI_RES", ignoreCase = true) ||
+                    resolvedQuality.contains("HIRES", ignoreCase = true) ||
+                    resolvedQuality.contains("MAX", ignoreCase = true) ||
+                    (dataBitDepth ?: 0) >= 24 ||
+                    (dataSampleRate ?: manifest.sampleRate ?: 0) > 48_000
+            if (
+                audioQuality == TidalAudioQuality.HI_RES_LOSSLESS &&
+                quality.isLosslessQuality() &&
+                !returnedHiRes
+            ) {
+                throw TidalAudioResolutionException(
+                    "TIDAL HiRes was unavailable for ${track.title}; resolver returned ${resolvedQuality.ifBlank { quality }}",
+                )
+            }
+
+            val localFile = if (manifest.isDash && manifestLooksFlac && cacheDir != null) {
+                downloadDashFlacToTempFile(track, quality, manifest, cacheDir)
+            } else if (!preferLiveDash && manifest.isDash && cacheDir != null) {
+                downloadManifestToTempFile(track, quality, manifest, cacheDir)
+            } else {
+                null
+            }
+            val liveManifestFile = if (localFile == null && preferLiveDash && manifest.isDash && cacheDir != null) {
+                writeDashManifestToTempFile(track, quality, manifest, cacheDir)
+            } else {
+                null
+            }
+            val streamUri = liveManifestFile
+                ?.let { Uri.fromFile(it).toString() }
+                ?: localFile?.let { Uri.fromFile(it).toString() }
+                ?: manifest.url
+            val playbackStreamInfo = localFile
+                ?.let { inspectLocalPlaybackFile(it, manifest) }
+                ?: if (liveManifestFile == null && !manifest.isDash) {
+                    inspectRemotePlaybackUrl(manifest.url, manifest)
+                } else {
+                    null
+                }
+            val resolvedCodecs = playbackStreamInfo?.codecs
+                ?: manifest.codecs.takeIf { it.isNotBlank() }
+                ?: when {
+                    manifestLooksFlac -> "flac"
+                    isAtmosManifest -> "ec-3"
+                    else -> "mp4a.40.2"
+                }
+            val playbackMimeType = if (liveManifestFile != null) {
+                DASH_MIME_TYPE
+            } else {
+                playbackStreamInfo?.mimeType ?: manifest.mimeType.coerceDirectPlaybackMimeType(manifest.url)
+            }
+            val isResolvedFlacLike =
+                playbackMimeType.contains("flac", ignoreCase = true) ||
+                    resolvedCodecs.contains("flac", ignoreCase = true)
+            val isLosslessDowngrade = quality.isLosslessQuality() && !isResolvedFlacLike && !isAtmosManifest
+            if (quality.equals("HI_RES_LOSSLESS", ignoreCase = true) && isLosslessDowngrade) {
+                throw TidalAudioResolutionException(
+                    "TIDAL $quality did not return FLAC (${playbackMimeType}, ${resolvedCodecs})",
+                )
+            }
+            val streamMetadata = when {
+                liveManifestFile != null -> StreamMetadata(playbackMimeType, null)
+                playbackStreamInfo != null -> StreamMetadata(
+                    playbackStreamInfo.mimeType,
+                    playbackStreamInfo.contentLength,
+                )
+                manifest.isDash -> throw TidalAudioResolutionException("TIDAL DASH manifest needs live DASH playback")
+                else -> fetchStreamMetadata(manifest.url)
+            }
+            val sampleRate = dataSampleRate
+                ?: manifest.sampleRate
+                ?: normalizeSampleRate(track.sampleRate?.toDouble())
+            val bitrate = manifest.bitrate ?: estimateBitrate(streamMetadata.contentLength, effectiveDurationMs)
+            validateLikelyFullTrack(track, effectiveDurationMs, streamMetadata.contentLength)
+            val resolvedLabel = when {
+                isAtmosManifest -> "TIDAL Atmos"
+                isLosslessDowngrade -> "TIDAL AAC"
+                resolvedQuality.contains("HI_RES", ignoreCase = true) -> "TIDAL HiRes FLAC"
+                quality.isLossyQuality() || resolvedQuality.equals("HIGH", ignoreCase = true) -> "TIDAL AAC"
+                else -> "TIDAL FLAC"
+            }
+            val losslessDowngradedBitrateKbps =
+                if (isLosslessDowngrade) ((bitrate ?: 320_000) / 1000).coerceAtLeast(1) else null
+            Timber.tag("TidalAudio").i(
+                "Resolved TIDAL ${resolvedQuality.ifBlank { quality }} stream for ${track.trackId}: label=$resolvedLabel, local=${localFile != null}, dash=${manifest.isDash}, bitrate=$bitrate, sampleRate=$sampleRate",
+            )
+
+            return Resolved(
+                mediaUri = streamUri,
+                trackId = track.trackId,
+                label = resolvedLabel,
+                mimeType = playbackMimeType,
+                codecs = resolvedCodecs,
+                bitrate = bitrate ?: if (isLosslessDowngrade) 320_000 else 0,
+                sampleRate = sampleRate,
+                contentLength = streamMetadata.contentLength,
+                expiresAtMs = (localFile ?: liveManifestFile)?.let { now + STREAM_CACHE_MS }
+                    ?: extractExpiryMs(manifest.expiryUrl ?: manifest.url, now),
+                losslessDowngradedBitrateKbps = losslessDowngradedBitrateKbps,
+                isLiveManifest = liveManifestFile != null,
+            )
+        }
+    }
+
+    private fun streamQualityCandidates(
+        track: MatchedTrack,
+        preferAtmos: Boolean,
+        audioQuality: TidalAudioQuality,
+    ): List<String> =
+        buildList {
+            if (preferAtmos && audioQuality != TidalAudioQuality.AAC_320) {
+                add("DOLBY_ATMOS")
+            }
+            when (audioQuality) {
+                TidalAudioQuality.AAC_320 -> add("HIGH")
+                TidalAudioQuality.FLAC -> {
+                    if (track.supportsHiResLossless() || track.supportsLossless()) {
+                        add("LOSSLESS")
+                    }
+                    add("HIGH")
+                }
+                TidalAudioQuality.HI_RES_LOSSLESS -> {
+                    if (track.supportsHiResLossless()) {
+                        add("HI_RES_LOSSLESS")
+                    }
+                    if (track.supportsHiResLossless() || track.supportsLossless()) {
+                        add("LOSSLESS")
+                    }
+                    add("HIGH")
+                }
+            }
+        }.distinct()
+
+    private fun String.tidalManifestFormats(): List<String>? =
+        when {
+            equals("DOLBY_ATMOS", ignoreCase = true) -> listOf("EAC3_JOC")
+            equals("HI_RES_LOSSLESS", ignoreCase = true) ||
+                equals("HI_RES", ignoreCase = true) -> listOf("FLAC_HIRES")
+            equals("LOSSLESS", ignoreCase = true) -> listOf("FLAC")
+            else -> null
+        }
+
+    private fun List<String>.toResolvedTidalQuality(requestedQuality: String): String =
+        when {
+            any { it.equals("EAC3_JOC", ignoreCase = true) } -> "DOLBY_ATMOS"
+            any { it.equals("FLAC_HIRES", ignoreCase = true) } -> "HI_RES_LOSSLESS"
+            any { it.equals("FLAC", ignoreCase = true) } -> "LOSSLESS"
+            else -> requestedQuality
+        }
+
+    private fun String.isLosslessQuality(): Boolean =
+        equals("LOSSLESS", ignoreCase = true) ||
+            equals("HI_RES_LOSSLESS", ignoreCase = true) ||
+            equals("HI_RES", ignoreCase = true)
+
+    private fun String.isLossyQuality(): Boolean =
+        equals("HIGH", ignoreCase = true) ||
+            equals("LOW", ignoreCase = true)
+
+    private fun parseManifest(
+        manifestB64: String,
+        declaredMimeType: String?,
+        durationMs: Long?,
+    ): ParsedManifest {
+        val text =
+            String(
+                Base64.decode(manifestB64.trim(), Base64.DEFAULT),
+                Charsets.UTF_8,
+            ).trim()
+        return parseManifestText(text, declaredMimeType, durationMs)
+    }
+
+    private fun parseManifestText(
+        text: String,
+        declaredMimeType: String?,
+        durationMs: Long? = null,
+    ): ParsedManifest {
+        val cleanText = text.trim()
+        if (cleanText.isBlank()) {
+            throw TidalAudioResolutionException("TIDAL FLAC manifest was empty")
+        }
+        if (cleanText.startsWith("{")) {
+            val root = JSONObject(cleanText)
+            val urls = root.optJSONArray("urls")
+                ?: throw TidalAudioResolutionException("TIDAL FLAC manifest had no URLs")
+            val directUrl = urls.firstStringOrNull()
+                ?: throw TidalAudioResolutionException("TIDAL FLAC manifest URL was empty")
+            val rawMimeType = root.stringOrNull("mimeType") ?: AUDIO_FLAC_MIME_TYPE
+            val codecs = root.stringOrNull("codecs") ?: if (rawMimeType.contains("flac", ignoreCase = true)) "flac" else "mp4a.40.2"
+            val mimeType = rawMimeType.coerceDirectPlaybackMimeType(directUrl)
+            val sampleRate = normalizeSampleRate(root.doubleOrNull("sampleRate"))
+            val bitrate = root.longOrNull("bitrate")?.coerceAtMost(Int.MAX_VALUE.toLong())?.toInt()
+                ?: root.longOrNull("bandwidth")?.coerceAtMost(Int.MAX_VALUE.toLong())?.toInt()
+            return ParsedManifest(
+                url = directUrl,
+                mimeType = mimeType,
+                codecs = codecs,
+                sampleRate = sampleRate,
+                bitrate = bitrate,
+                expiryUrl = directUrl,
+                isDash = false,
+                outputExtension = if (mimeType.contains("flac", ignoreCase = true) || codecs.contains("flac", ignoreCase = true)) {
+                    ".flac"
+                } else {
+                    ".m4a"
+                },
+            )
+        }
+        if (cleanText.contains("<MPD", ignoreCase = true)) {
+            return parseDashManifest(cleanText.sanitizeXmlEntities(), declaredMimeType)
+        }
+        throw TidalAudioResolutionException("TIDAL FLAC manifest format was not recognized")
+    }
+
+    private fun parseDashManifest(
+        text: String,
+        declaredMimeType: String?,
+    ): ParsedManifest {
+        if (
+            !text.contains("<SegmentTemplate", ignoreCase = true) &&
+            !text.contains("<SegmentList", ignoreCase = true) &&
+            !text.contains("<SegmentBase", ignoreCase = true) &&
+            !text.contains("<BaseURL", ignoreCase = true)
+        ) {
+            throw TidalAudioResolutionException("TIDAL DASH manifest had no playable segments")
+        }
+        val codecs = firstXmlAttr(text, "codecs").ifBlank { "flac" }
+        val representationMime = firstXmlAttr(text, "mimeType")
+        val sampleRate = firstXmlAttr(text, "audioSamplingRate").toIntOrNull()
+        val bandwidth = xmlAttrValues(text, "bandwidth").maxOrNull()
+        val segmentUrls = extractDashSegmentUrls(text)
+        val firstSegmentUrl = Regex("""https?://[^"'<>\s]+""")
+            .find(text)
+            ?.value
+            ?.xmlUnescape()
+        return ParsedManifest(
+            url = "",
+            mimeType = representationMime.ifBlank { declaredMimeType ?: "audio/mp4" },
+            codecs = codecs,
+            sampleRate = sampleRate,
+            bitrate = bandwidth,
+            expiryUrl = firstSegmentUrl,
+            isDash = true,
+            segmentUrls = segmentUrls,
+            outputExtension = ".m4a",
+            manifestText = text,
+        )
+    }
+
+    private fun String.coerceDirectPlaybackMimeType(url: String): String {
+        if (!contains("dash", ignoreCase = true)) return this
+        return when {
+            url.endsWith(".flac", ignoreCase = true) -> AUDIO_FLAC_MIME_TYPE
+            else -> AUDIO_MP4_MIME_TYPE
+        }
+    }
+
+    private fun extractDashSegmentUrls(text: String): List<String> {
+        extractSegmentListUrls(text).takeIf { it.isNotEmpty() }?.let { return it }
+
+        val baseUrl = firstXmlTagValue(text, "BaseURL").xmlUnescape()
+        val init = firstXmlAttr(text, "initialization").xmlUnescape()
+        val mediaTemplate = firstXmlAttr(text, "media").xmlUnescape()
+        if (init.isBlank() || mediaTemplate.isBlank()) {
+            val directBase = baseUrl.takeIf { it.startsWith("http://", ignoreCase = true) || it.startsWith("https://", ignoreCase = true) }
+            if (directBase != null) return listOf(directBase)
+            throw TidalAudioResolutionException("TIDAL DASH manifest had no initialization/media templates")
+        }
+
+        var segmentCount = 0
+        Regex("""<S\s+[^>]*d="(\d+)"(?:\s+r="(-?\d+)")?[^>]*/?>""", RegexOption.IGNORE_CASE)
+            .findAll(text)
+            .forEach { match ->
+                val repeat = match.groupValues.getOrNull(2)?.toIntOrNull()?.takeIf { it > 0 } ?: 0
+                segmentCount += repeat + 1
+            }
+        if (segmentCount <= 0) {
+            throw TidalAudioResolutionException("TIDAL DASH manifest listed no media segments")
+        }
+
+        return buildList {
+            add(resolveDashUrl(baseUrl, init))
+            for (index in 1..segmentCount) {
+                add(resolveDashUrl(baseUrl, mediaTemplate.replace("\$Number\$", index.toString())))
+            }
+        }
+    }
+
+    private fun extractSegmentListUrls(text: String): List<String> {
+        val baseUrl = firstXmlTagValue(text, "BaseURL").xmlUnescape()
+        val initialization =
+            Regex("<Initialization\\b[^>]*sourceURL=\"([^\"]+)\"", RegexOption.IGNORE_CASE)
+                .find(text)
+                ?.groupValues
+                ?.getOrNull(1)
+                ?.xmlUnescape()
+        val mediaSegments =
+            Regex("<SegmentURL\\b[^>]*media=\"([^\"]+)\"", RegexOption.IGNORE_CASE)
+                .findAll(text)
+                .mapNotNull { it.groupValues.getOrNull(1)?.xmlUnescape() }
+                .toList()
+        return buildList {
+            initialization?.let { add(resolveDashUrl(baseUrl, it)) }
+            mediaSegments.forEach { add(resolveDashUrl(baseUrl, it)) }
+        }
+    }
+
+    private fun resolveDashUrl(
+        baseUrl: String,
+        path: String,
+    ): String {
+        if (path.startsWith("http://", ignoreCase = true) || path.startsWith("https://", ignoreCase = true)) {
+            return path
+        }
+        if (baseUrl.isBlank()) return path
+        val absoluteBase = baseUrl.takeIf {
+            it.startsWith("http://", ignoreCase = true) || it.startsWith("https://", ignoreCase = true)
+        } ?: return path
+        return absoluteBase.toHttpUrlOrNull()
+            ?.resolve(path)
+            ?.toString()
+            ?: absoluteBase.trimEnd('/') + "/" + path.trimStart('/')
+    }
+
+    private fun downloadDashFlacToTempFile(
+        track: MatchedTrack,
+        quality: String,
+        manifest: ParsedManifest,
+        cacheDir: File,
+    ): File {
+        val urls = manifest.segmentUrls
+        if (urls.size < 2 || urls.any { it.isBlank() }) {
+            throw TidalAudioResolutionException("TIDAL HiRes DASH manifest did not list FLAC segments")
+        }
+
+        val tidalDir = File(cacheDir, "tidal-temp").apply { mkdirs() }
+        val outputFile = File(
+            tidalDir,
+            "${track.trackId}-${quality.lowercase(Locale.US)}-${System.currentTimeMillis()}.flac",
+        )
+
+        try {
+            val initBytes = downloadSegmentBytes(urls.first(), 1, urls.size)
+            val flacMetadataBlocks = extractFlacMetadataBlocks(initBytes)
+            outputFile.outputStream().buffered().use { out ->
+                out.write(byteArrayOf('f'.code.toByte(), 'L'.code.toByte(), 'a'.code.toByte(), 'C'.code.toByte()))
+                out.write(flacMetadataBlocks)
+                urls.drop(1).forEachIndexed { index, url ->
+                    val segmentBytes = downloadSegmentBytes(url, index + 2, urls.size)
+                    writeMdatPayloads(segmentBytes, out)
+                }
+            }
+        } catch (error: Throwable) {
+            outputFile.delete()
+            if (error is TidalAudioResolutionException) throw error
+            throw TidalAudioResolutionException("TIDAL HiRes FLAC remux failed: ${error.message}", error)
+        }
+
+        if (outputFile.length() <= 42L) {
+            outputFile.delete()
+            throw TidalAudioResolutionException("TIDAL HiRes FLAC remux produced an empty file")
+        }
+        return outputFile
+    }
+
+    private fun downloadSegmentBytes(
+        url: String,
+        index: Int,
+        total: Int,
+    ): ByteArray {
+        val request =
+            Request
+                .Builder()
+                .url(url)
+                .get()
+                .header("Accept", "audio/mp4,audio/*,*/*;q=0.8")
+                .header("Accept-Encoding", "identity")
+                .header("User-Agent", BROWSER_USER_AGENT)
+                .build()
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw TidalAudioResolutionException("TIDAL segment $index/$total HTTP ${response.code}")
+            }
+            return response.body.bytes()
+        }
+    }
+
+    private fun extractFlacMetadataBlocks(initBytes: ByteArray): ByteArray {
+        val typeOffset = initBytes.indexOfAscii("dfLa")
+        if (typeOffset < 4) {
+            throw TidalAudioResolutionException("TIDAL HiRes init segment had no FLAC metadata")
+        }
+        val boxStart = typeOffset - 4
+        val boxSize = initBytes.readMp4BoxSize(boxStart)
+        val boxEnd = boxStart + boxSize
+        val payloadStart = typeOffset + 8
+        if (boxSize < 16 || payloadStart + 4 > boxEnd || boxEnd > initBytes.size) {
+            throw TidalAudioResolutionException("TIDAL HiRes FLAC metadata box was invalid")
+        }
+        val metadataBlocks = initBytes.copyOfRange(payloadStart, boxEnd)
+        val firstBlockType = metadataBlocks[0].toInt() and 0x7f
+        val firstBlockLength =
+            ((metadataBlocks[1].toInt() and 0xff) shl 16) or
+                ((metadataBlocks[2].toInt() and 0xff) shl 8) or
+                (metadataBlocks[3].toInt() and 0xff)
+        if (firstBlockType != 0 || firstBlockLength != 34 || metadataBlocks.size < 4 + firstBlockLength) {
+            throw TidalAudioResolutionException("TIDAL HiRes FLAC STREAMINFO was invalid")
+        }
+        return metadataBlocks
+    }
+
+    private fun writeMdatPayloads(
+        bytes: ByteArray,
+        out: OutputStream,
+    ) {
+        var foundMdat = false
+        var offset = 0
+        while (offset + MP4_BOX_HEADER_SIZE <= bytes.size) {
+            val size = bytes.readMp4BoxSize(offset)
+            val type = bytes.readMp4BoxType(offset + 4)
+            val headerSize = if (bytes.readUInt32(offset) == 1L) MP4_EXTENDED_BOX_HEADER_SIZE else MP4_BOX_HEADER_SIZE
+            val boxEnd = offset + size
+            if (size < headerSize || boxEnd > bytes.size) {
+                throw TidalAudioResolutionException("TIDAL HiRes segment had an invalid MP4 box")
+            }
+            if (type == "mdat") {
+                out.write(bytes, offset + headerSize, size - headerSize)
+                foundMdat = true
+            }
+            offset = boxEnd
+        }
+        if (!foundMdat) {
+            throw TidalAudioResolutionException("TIDAL HiRes segment had no audio payload")
+        }
+    }
+
+    private fun ByteArray.indexOfAscii(value: String): Int {
+        val needle = value.toByteArray(Charsets.US_ASCII)
+        if (needle.isEmpty() || size < needle.size) return -1
+        for (index in 0..size - needle.size) {
+            var matches = true
+            for (needleIndex in needle.indices) {
+                if (this[index + needleIndex] != needle[needleIndex]) {
+                    matches = false
+                    break
+                }
+            }
+            if (matches) return index
+        }
+        return -1
+    }
+
+    private fun ByteArray.readMp4BoxSize(offset: Int): Int {
+        val size32 = readUInt32(offset)
+        val size = when (size32) {
+            0L -> this.size.toLong() - offset.toLong()
+            1L -> readUInt64(offset + 8)
+            else -> size32
+        }
+        if (size <= 0L || size > Int.MAX_VALUE) {
+            throw TidalAudioResolutionException("TIDAL HiRes segment had an invalid MP4 box size")
+        }
+        return size.toInt()
+    }
+
+    private fun ByteArray.readUInt32(offset: Int): Long {
+        if (offset < 0 || offset + 4 > size) {
+            throw TidalAudioResolutionException("TIDAL HiRes segment had a truncated MP4 box")
+        }
+        return ((this[offset].toLong() and 0xffL) shl 24) or
+            ((this[offset + 1].toLong() and 0xffL) shl 16) or
+            ((this[offset + 2].toLong() and 0xffL) shl 8) or
+            (this[offset + 3].toLong() and 0xffL)
+    }
+
+    private fun ByteArray.readUInt64(offset: Int): Long {
+        if (offset < 0 || offset + 8 > size) {
+            throw TidalAudioResolutionException("TIDAL HiRes segment had a truncated large MP4 box")
+        }
+        var value = 0L
+        for (index in 0 until 8) {
+            value = (value shl 8) or (this[offset + index].toLong() and 0xffL)
+        }
+        return value
+    }
+
+    private fun ByteArray.readMp4BoxType(offset: Int): String {
+        if (offset < 0 || offset + 4 > size) {
+            throw TidalAudioResolutionException("TIDAL HiRes segment had a truncated MP4 type")
+        }
+        return String(this, offset, 4, Charsets.US_ASCII)
+    }
+
+    private fun downloadManifestToTempFile(
+        track: MatchedTrack,
+        quality: String,
+        manifest: ParsedManifest,
+        cacheDir: File,
+    ): File {
+        val tidalDir = File(cacheDir, "tidal-temp").apply { mkdirs() }
+        val outputFile = File(
+            tidalDir,
+            "${track.trackId}-${quality.lowercase(Locale.US)}-${System.currentTimeMillis()}${manifest.outputExtension}",
+        )
+        val urls = if (manifest.isDash) manifest.segmentUrls else listOf(manifest.url)
+        if (urls.any { it.isBlank() }) {
+            throw TidalAudioResolutionException("TIDAL manifest contained an empty URL")
+        }
+
+        try {
+            outputFile.outputStream().buffered().use { out ->
+                urls.forEachIndexed { index, url ->
+                    val request =
+                        Request
+                            .Builder()
+                            .url(url)
+                            .get()
+                            .header("Accept", "audio/flac,audio/mp4,audio/*,*/*;q=0.8")
+                            .header("Accept-Encoding", "identity")
+                            .header("User-Agent", BROWSER_USER_AGENT)
+                            .build()
+                    client.newCall(request).execute().use { response ->
+                        if (!response.isSuccessful) {
+                            throw TidalAudioResolutionException(
+                                "TIDAL segment ${index + 1}/${urls.size} HTTP ${response.code}",
+                            )
+                        }
+                        response.body.byteStream().use { input ->
+                            input.copyTo(out)
+                        }
+                    }
+                }
+            }
+        } catch (error: Throwable) {
+            outputFile.delete()
+            if (error is TidalAudioResolutionException) throw error
+            throw TidalAudioResolutionException("TIDAL temporary download failed: ${error.message}", error)
+        }
+
+        if (outputFile.length() <= 0L) {
+            outputFile.delete()
+            throw TidalAudioResolutionException("TIDAL temporary download produced an empty file")
+        }
+        return outputFile
+    }
+
+    private fun inspectLocalPlaybackFile(
+        file: File,
+        manifest: ParsedManifest,
+    ): PlaybackStreamInfo {
+        val length = file.length()
+        if (length <= 0L) {
+            file.delete()
+            throw TidalAudioResolutionException("TIDAL temporary file was empty")
+        }
+
+        val header = ByteArray(16)
+        val bytesRead = file.inputStream().use { input -> input.read(header) }
+        val isFlac =
+            bytesRead >= 4 &&
+                header[0] == 'f'.code.toByte() &&
+                header[1] == 'L'.code.toByte() &&
+                header[2] == 'a'.code.toByte() &&
+                header[3] == 'C'.code.toByte()
+        val isMp4 =
+            bytesRead >= 12 &&
+                header[4] == 'f'.code.toByte() &&
+                header[5] == 't'.code.toByte() &&
+                header[6] == 'y'.code.toByte() &&
+                header[7] == 'p'.code.toByte()
+
+        if (isFlac) {
+            return PlaybackStreamInfo(
+                mimeType = AUDIO_FLAC_MIME_TYPE,
+                codecs = "flac",
+                contentLength = length,
+            )
+        }
+        if (isMp4) {
+            return PlaybackStreamInfo(
+                mimeType = AUDIO_MP4_MIME_TYPE,
+                codecs = manifest.codecs.takeIf { it.isNotBlank() } ?: "mp4a.40.2",
+                contentLength = length,
+            )
+        }
+
+        val headerText = header
+            .take(bytesRead.coerceAtLeast(0))
+            .map { byte ->
+                val value = byte.toInt() and 0xff
+                if (value in 32..126) value.toChar() else '.'
+            }
+            .joinToString("")
+            .trim()
+        file.delete()
+        throw TidalAudioResolutionException(
+            "TIDAL temporary file was not a playable FLAC/MP4 container (${headerText.ifBlank { "binary header" }})",
+        )
+    }
+
+    private fun inspectRemotePlaybackUrl(
+        url: String,
+        manifest: ParsedManifest,
+    ): PlaybackStreamInfo {
+        val request =
+            Request
+                .Builder()
+                .url(url)
+                .get()
+                .header("Accept", "audio/flac,audio/mp4,audio/*,*/*;q=0.8")
+                .header("Accept-Encoding", "identity")
+                .header("Range", "bytes=0-15")
+                .header("User-Agent", BROWSER_USER_AGENT)
+                .build()
+
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw TidalAudioResolutionException("TIDAL stream probe HTTP ${response.code}")
+            }
+            val header = ByteArray(16)
+            val bytesRead = response.body.byteStream().use { input -> input.read(header) }
+            val contentLength =
+                response.header("Content-Range")
+                    ?.substringAfterLast('/', missingDelimiterValue = "")
+                    ?.toLongOrNull()
+                    ?.takeIf { it > 0L }
+                    ?: response.header("Content-Length")?.toLongOrNull()?.takeIf { it > 0L && response.code != 206 }
+
+            return inspectPlaybackHeader(
+                bytes = header,
+                bytesRead = bytesRead,
+                manifest = manifest,
+                contentLength = contentLength,
+                label = "TIDAL stream",
+            )
+        }
+    }
+
+    private fun inspectPlaybackHeader(
+        bytes: ByteArray,
+        bytesRead: Int,
+        manifest: ParsedManifest,
+        contentLength: Long?,
+        label: String,
+    ): PlaybackStreamInfo {
+        val isFlac =
+            bytesRead >= 4 &&
+                bytes[0] == 'f'.code.toByte() &&
+                bytes[1] == 'L'.code.toByte() &&
+                bytes[2] == 'a'.code.toByte() &&
+                bytes[3] == 'C'.code.toByte()
+        val isMp4 =
+            bytesRead >= 12 &&
+                bytes[4] == 'f'.code.toByte() &&
+                bytes[5] == 't'.code.toByte() &&
+                bytes[6] == 'y'.code.toByte() &&
+                bytes[7] == 'p'.code.toByte()
+
+        if (isFlac) {
+            return PlaybackStreamInfo(
+                mimeType = AUDIO_FLAC_MIME_TYPE,
+                codecs = "flac",
+                contentLength = contentLength,
+            )
+        }
+        if (isMp4) {
+            return PlaybackStreamInfo(
+                mimeType = AUDIO_MP4_MIME_TYPE,
+                codecs = manifest.codecs.takeIf { it.isNotBlank() } ?: "mp4a.40.2",
+                contentLength = contentLength,
+            )
+        }
+
+        val headerText = bytes
+            .take(bytesRead.coerceAtLeast(0))
+            .map { byte ->
+                val value = byte.toInt() and 0xff
+                if (value in 32..126) value.toChar() else '.'
+            }
+            .joinToString("")
+            .trim()
+        throw TidalAudioResolutionException(
+            "$label was not a playable FLAC/MP4 container (${headerText.ifBlank { "binary header" }})",
+        )
+    }
+
+    private fun writeDashManifestToTempFile(
+        track: MatchedTrack,
+        quality: String,
+        manifest: ParsedManifest,
+        cacheDir: File,
+    ): File {
+        val manifestText = manifest.manifestText
+            ?: throw TidalAudioResolutionException("TIDAL live DASH manifest text was missing")
+        val tidalDir = File(cacheDir, "tidal-temp").apply { mkdirs() }
+        val outputFile = File(
+            tidalDir,
+            "${track.trackId}-${quality.lowercase(Locale.US)}-${System.currentTimeMillis()}.mpd",
+        )
+        runCatching {
+            outputFile.writeText(manifestText, Charsets.UTF_8)
+        }.onFailure { error ->
+            outputFile.delete()
+            throw TidalAudioResolutionException("TIDAL live manifest write failed: ${error.message}", error)
+        }
+        if (outputFile.length() <= 0L) {
+            outputFile.delete()
+            throw TidalAudioResolutionException("TIDAL live manifest file was empty")
+        }
+        return outputFile
+    }
+
+    private fun cleanupTempFiles(cacheDir: File) {
+        val tidalDir = File(cacheDir, "tidal-temp")
+        if (!tidalDir.exists()) return
+        val cutoff = System.currentTimeMillis() - TEMP_FILE_MAX_AGE_MS
+        tidalDir.listFiles()?.forEach { file ->
+            if (file.isFile && file.lastModified() < cutoff) {
+                file.delete()
+            }
+        }
+    }
+
+    private fun fetchStreamMetadata(url: String): StreamMetadata {
+        val httpUrl = url.toHttpUrlOrNull() ?: return StreamMetadata("audio/flac", null)
+        val builder =
+            Request
+                .Builder()
+                .url(httpUrl)
+                .header("Accept", "audio/flac,audio/mp4,audio/*,*/*;q=0.8")
+                .header("Accept-Encoding", "identity")
+                .header("User-Agent", BROWSER_USER_AGENT)
+
+        runCatching {
+            client.newCall(builder.head().build()).execute().use { response ->
+                if (!response.isSuccessful) return@use null
+                StreamMetadata(
+                    mimeType = response.header("Content-Type")?.substringBefore(';'),
+                    contentLength = response.header("Content-Length")?.toLongOrNull()?.takeIf { it > 0L },
+                )
+            }
+        }.getOrNull()?.let { return it }
+
+        return runCatching {
+            client.newCall(
+                builder
+                    .get()
+                    .header("Range", "bytes=0-0")
+                    .build(),
+            ).execute().use { response ->
+                StreamMetadata(
+                    mimeType = response.header("Content-Type")?.substringBefore(';'),
+                    contentLength =
+                        response.header("Content-Range")
+                            ?.substringAfterLast('/', missingDelimiterValue = "")
+                            ?.toLongOrNull()
+                            ?.takeIf { it > 0L }
+                            ?: response.header("Content-Length")?.toLongOrNull()?.takeIf { it > 0L && response.code == 206 },
+                )
+            }
+        }.getOrElse {
+            StreamMetadata("audio/flac", null)
+        }
+    }
+
+    private fun fetchText(url: String): String {
+        val request =
+            Request
+                .Builder()
+                .url(url)
+                .get()
+                .header("Accept", "application/dash+xml,application/xml,text/xml,*/*;q=0.8")
+                .header("User-Agent", DOWNLOAD_USER_AGENT)
+                .build()
+        client.newCall(request).execute().use { response ->
+            val body = response.body.string()
+            if (!response.isSuccessful) {
+                throw TidalAudioResolutionException("TIDAL manifest fetch HTTP ${response.code}: ${body.take(180)}")
+            }
+            return body.takeIf { it.isNotBlank() }
+                ?: throw TidalAudioResolutionException("TIDAL manifest fetch returned an empty body")
+        }
+    }
+
+    private fun validateLikelyFullTrack(
+        track: MatchedTrack,
+        durationMs: Long?,
+        contentLength: Long?,
+    ) {
+        val duration = durationMs?.takeIf { it >= 60_000L } ?: return
+        val length = contentLength?.takeIf { it > 0L } ?: return
+        val minimumBytesForFullTrack = (duration / 1000.0 * 96_000.0 / 8.0 * 0.70).toLong()
+        if (length < minimumBytesForFullTrack) {
+            throw TidalAudioResolutionException(
+                "TIDAL returned a likely preview for ${track.title}: $length bytes for ${duration / 1000L}s",
+            )
+        }
+    }
+
+    private fun searchTerms(query: Query): List<String> =
+        buildList {
+            val title = query.title.searchQueryTitle()
+            val primaryArtist = query.artists
+                .firstOrNull { it.isNotBlank() }
+                ?.searchQueryArtist()
+                .orEmpty()
+            val titleAndArtist = listOf(title, primaryArtist)
+                .filter { it.isNotBlank() }
+                .joinToString(" ")
+            add(titleAndArtist)
+        }.map { it.trim() }
+            .filter { it.isNotBlank() }
+            .distinct()
+
+    private fun Query.toDirectMatchedTrack(trackId: String): MatchedTrack =
+        MatchedTrack(
+            trackId = trackId,
+            title = title,
+            artistNames = artists,
+            album = album,
+            isrc = isrc,
+            durationMs = durationMs,
+            audioQuality = null,
+            mediaTags = emptySet(),
+            audioModes = emptySet(),
+            sampleRate = null,
+        )
+
+    private fun resolveSongLinkTidalTrackId(query: Query): String? {
+        for (sourceUrl in songLinkSourceUrls(query.mediaId)) {
+            val url =
+                SONG_LINK_API_URL
+                    .toHttpUrl()
+                    .newBuilder()
+                    .addQueryParameter("url", sourceUrl)
+                    .build()
+            val request =
+                Request
+                    .Builder()
+                    .url(url)
+                    .get()
+                    .header("Accept", "application/json")
+                    .header("User-Agent", BROWSER_USER_AGENT)
+                    .build()
+            runCatching {
+                client.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) return@use null
+                    val body = response.body.string().takeIf { it.isNotBlank() } ?: return@use null
+                    val root = JSONObject(body)
+                    root.optJSONObject("linksByPlatform")
+                        ?.optJSONObject("tidal")
+                        ?.stringOrNull("url")
+                        ?.toTidalTrackIdOrNull()
+                        ?: root.optJSONObject("songUrls")
+                            ?.stringOrNull("Tidal")
+                            ?.toTidalTrackIdOrNull()
+                }
+            }.getOrNull()?.let { trackId ->
+                Timber.tag("TidalAudio").i("Resolved TIDAL track $trackId through song.link from $sourceUrl")
+                return trackId
+            }
+        }
+        return null
+    }
+
+    private fun songLinkSourceUrls(mediaId: String): List<String> {
+        val trimmed = mediaId.trim()
+        if (trimmed.isBlank()) return emptyList()
+        return buildList {
+            if (trimmed.startsWith("http://", ignoreCase = true) || trimmed.startsWith("https://", ignoreCase = true)) {
+                add(trimmed)
+            }
+            Regex("""spotify[:/](?:track[:/])?([A-Za-z0-9]{22})""", RegexOption.IGNORE_CASE)
+                .find(trimmed)
+                ?.groupValues
+                ?.getOrNull(1)
+                ?.let { add("https://open.spotify.com/track/$it") }
+            if (trimmed.matches(Regex("[A-Za-z0-9]{22}"))) {
+                add("https://open.spotify.com/track/$trimmed")
+            }
+            if (trimmed.matches(Regex("[A-Za-z0-9_-]{11}"))) {
+                add("https://music.youtube.com/watch?v=$trimmed")
+            }
+        }.distinct()
+    }
+
+    private fun estimateBitrate(
+        contentLength: Long?,
+        durationMs: Long?,
+    ): Int? {
+        val length = contentLength?.takeIf { it > 0L } ?: return null
+        val duration = durationMs?.takeIf { it > 0L } ?: return null
+        val bitrate = (length * 8L * 1000L) / duration
+        return bitrate
+            .takeIf { it in 32_000L..20_000_000L }
+            ?.coerceAtMost(Int.MAX_VALUE.toLong())
+            ?.toInt()
+    }
+
+    private fun normalizeSampleRate(value: Double?): Int? {
+        val sampleRate = value?.takeIf { it > 0.0 } ?: return null
+        return when {
+            sampleRate < 1000.0 -> (sampleRate * 1000.0).roundToInt()
+            else -> sampleRate.roundToInt()
+        }.takeIf { it > 0 }
+    }
+
+    private fun extractExpiryMs(
+        url: String,
+        now: Long,
+    ): Long {
+        val httpUrl = url.toHttpUrlOrNull() ?: return now + STREAM_CACHE_MS
+        val expiresSeconds = httpUrl.queryParameterIgnoreCase("X-Amz-Expires")?.toLongOrNull()
+        val date = httpUrl.queryParameterIgnoreCase("X-Amz-Date")
+        if (expiresSeconds != null && date != null) {
+            runCatching {
+                val issuedAt = LocalDateTime.parse(date, AMAZON_DATE).toInstant(ZoneOffset.UTC).toEpochMilli()
+                return (issuedAt + expiresSeconds * 1000L - 30_000L).coerceAtLeast(now + 60_000L)
+            }
+        }
+        return now + STREAM_CACHE_MS
+    }
+
+    private fun JSONObject.toMatchedTrack(): MatchedTrack? {
+        val trackId = stringOrNull("id") ?: return null
+        val title = stringOrNull("title") ?: stringOrNull("name") ?: return null
+        val artists = collectArtistNames()
+        val album = optJSONObject("album")?.stringOrNull("title") ?: optJSONObject("album")?.stringOrNull("name")
+        return MatchedTrack(
+            trackId = trackId,
+            title = title,
+            artistNames = artists,
+            album = album,
+            isrc = stringOrNull("isrc"),
+            durationMs = longOrNull("duration")?.takeIf { it > 0L }?.times(1000L),
+            audioQuality = stringOrNull("audioQuality"),
+            mediaTags = collectMediaTags(),
+            audioModes = collectAudioModes(),
+            sampleRate = normalizeSampleRate(doubleOrNull("sampleRate")),
+        )
+    }
+
+    private fun JSONObject.collectArtistNames(): List<String> {
+        val names = mutableListOf<String>()
+        optJSONArray("artists")?.let { array ->
+            for (index in 0 until array.length()) {
+                array.optJSONObject(index)?.stringOrNull("name")?.takeIf { it.isNotBlank() }?.let(names::add)
+            }
+        }
+        optJSONObject("artist")?.stringOrNull("name")?.takeIf { it.isNotBlank() }?.let(names::add)
+        return names.distinct()
+    }
+
+    private fun JSONObject.collectMediaTags(): Set<String> {
+        val tags = mutableSetOf<String>()
+        optJSONObject("mediaMetadata")
+            ?.optJSONArray("tags")
+            ?.let { array ->
+                for (index in 0 until array.length()) {
+                    array.optString(index).takeIf { it.isNotBlank() }?.let(tags::add)
+                }
+            }
+        optJSONArray("mediaMetadataTags")
+            ?.let { array ->
+                for (index in 0 until array.length()) {
+                    array.optString(index).takeIf { it.isNotBlank() }?.let(tags::add)
+                }
+            }
+        return tags
+    }
+
+    private fun JSONObject.collectAudioModes(): Set<String> {
+        val modes = mutableSetOf<String>()
+        stringOrNull("audioMode")?.let(modes::add)
+        optJSONArray("audioModes")
+            ?.let { array ->
+                for (index in 0 until array.length()) {
+                    array.optString(index).takeIf { it.isNotBlank() }?.let(modes::add)
+                }
+            }
+        optJSONObject("mediaMetadata")
+            ?.optJSONArray("audioModes")
+            ?.let { array ->
+                for (index in 0 until array.length()) {
+                    array.optString(index).takeIf { it.isNotBlank() }?.let(modes::add)
+                }
+            }
+        return modes
+    }
+
+    private fun String.toTidalTrackIdOrNull(): String? {
+        val trimmed = trim()
+        if (trimmed.matches(Regex("\\d+"))) return trimmed
+        Regex("""^tidal:track:(\d+)$""", RegexOption.IGNORE_CASE)
+            .matchEntire(trimmed)
+            ?.groupValues
+            ?.getOrNull(1)
+            ?.let { return it }
+        Regex("""tidal\.com/(?:browse/)?track/(\d+)""", RegexOption.IGNORE_CASE)
+            .find(trimmed)
+            ?.groupValues
+            ?.getOrNull(1)
+            ?.let { return it }
+        return null
+    }
+
+    private fun String.trackCacheKeyFallback(): String = "direct:${trim().lowercase(Locale.US)}"
+
+    private fun Query.trackCacheKey(): String =
+        mediaId.toTidalTrackIdOrNull()
+            ?.let { "direct:$it" }
+            ?: listOf(
+                title.normalized(),
+                artists.joinToString(",") { it.normalized() },
+                album.normalized(),
+                durationMs?.div(1000L)?.toString().orEmpty(),
+            ).joinToString("::")
+
+    private fun String?.normalized(): String =
+        this
+            ?.lowercase(Locale.US)
+            ?.let { Normalizer.normalize(it, Normalizer.Form.NFD) }
+            ?.replace(Regex("\\p{Mn}+"), "")
+            ?.replace(Regex("[^a-z0-9]+"), " ")
+            ?.trim()
+            .orEmpty()
+
+    private fun String.titleMatchNormalized(): String =
+        normalized()
+            .replace(Regex("""\b(feat|ft|featuring)\b.*$"""), "")
+            .replace(Regex("""\b(explicit|clean|remaster|remastered|version|audio|official)\b"""), " ")
+            .replace(Regex("\\s+"), " ")
+            .trim()
+
+    private fun String.searchQueryTitle(): String =
+        trim()
+            .replace(Regex("""\s*[\[(]\s*(feat\.?|ft\.?|featuring)\b.*?[\])]""", RegexOption.IGNORE_CASE), "")
+            .replace(Regex("""\s*-\s*(explicit|clean|remaster(?:ed)?|audio|official)\b.*$""", RegexOption.IGNORE_CASE), "")
+            .replace(Regex("\\s+"), " ")
+            .trim()
+
+    private fun String.searchQueryArtist(): String =
+        trim()
+            .substringBefore(',')
+            .replace(Regex("\\s+"), " ")
+            .trim()
+
+    private fun significantTokens(value: String): Set<String> =
+        value
+            .split(' ')
+            .map { it.trim() }
+            .filter { it.length >= 2 && it !in STOP_WORDS }
+            .toSet()
+
+    private fun tokenOverlap(
+        wanted: Set<String>,
+        candidate: Set<String>,
+    ): Double {
+        if (wanted.isEmpty() || candidate.isEmpty()) return 0.0
+        val shared = wanted.intersect(candidate).size
+        return shared.toDouble() / wanted.size.coerceAtLeast(candidate.size).toDouble()
+    }
+
+    private fun durationMatches(
+        wantedDurationMs: Long?,
+        candidateDurationMs: Long?,
+    ): Boolean {
+        if (wantedDurationMs == null || candidateDurationMs == null) return true
+        return abs(wantedDurationMs - candidateDurationMs) <= 45_000L
+    }
+
+    private fun hasVersionMismatch(
+        wanted: String,
+        candidate: String,
+    ): Boolean {
+        val wantedLive = wanted.contains(" live ")
+        val candidateLive = candidate.contains(" live ")
+        if (wantedLive != candidateLive) return true
+        val wantedInstrumental = wanted.contains(" instrumental ")
+        val candidateInstrumental = candidate.contains(" instrumental ")
+        if (wantedInstrumental != candidateInstrumental) return true
+        return VERSION_TOKENS.any { token ->
+            wanted.hasToken(token) != candidate.hasToken(token)
+        }
+    }
+
+    private fun String.hasToken(token: String): Boolean =
+        split(' ').any { it == token }
+
+    private fun JSONArray.firstStringOrNull(): String? {
+        for (index in 0 until length()) {
+            val value = optString(index).takeIf { it.isNotBlank() }
+            if (value != null) return value
+        }
+        return null
+    }
+
+    private fun JSONObject.stringOrNull(key: String): String? =
+        optString(key).takeIf { it.isNotBlank() && it != "null" }
+
+    private fun JSONObject.longOrNull(key: String): Long? =
+        if (has(key)) optLong(key).takeIf { it > 0L } else null
+
+    private fun JSONObject.doubleOrNull(key: String): Double? =
+        if (has(key)) optDouble(key).takeIf { it > 0.0 && !it.isNaN() } else null
+
+    private fun HttpUrl.queryParameterIgnoreCase(name: String): String? {
+        val key = queryParameterNames.firstOrNull { it.equals(name, ignoreCase = true) } ?: return null
+        return queryParameter(key)
+    }
+
+    private fun firstXmlAttr(
+        text: String,
+        attr: String,
+    ): String =
+        Regex("""\b${Regex.escape(attr)}\s*=\s*"([^"]*)"""", RegexOption.IGNORE_CASE)
+            .find(text)
+            ?.groupValues
+            ?.getOrNull(1)
+            .orEmpty()
+
+    private fun xmlAttrValues(
+        text: String,
+        attr: String,
+    ): List<Int> =
+        Regex("""\b${Regex.escape(attr)}\s*=\s*"(\d+)"""", RegexOption.IGNORE_CASE)
+            .findAll(text)
+            .mapNotNull { it.groupValues.getOrNull(1)?.toIntOrNull() }
+            .toList()
+
+    private fun firstXmlTagValue(
+        text: String,
+        tag: String,
+    ): String =
+        Regex(
+            """<${Regex.escape(tag)}\b[^>]*>(.*?)</${Regex.escape(tag)}>""",
+            setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL),
+        ).find(text)
+            ?.groupValues
+            ?.getOrNull(1)
+            .orEmpty()
+            .trim()
+
+    private fun String.xmlUnescape(): String =
+        replace("&amp;", "&")
+            .replace("&quot;", "\"")
+            .replace("&apos;", "'")
+            .replace("&lt;", "<")
+            .replace("&gt;", ">")
+
+    private fun String.sanitizeXmlEntities(): String =
+        replace(Regex("""&(?!amp;|lt;|gt;|quot;|apos;|#\d+;|#x[0-9a-fA-F]+;)"""), "&amp;")
+
+    private fun String.deleteIfLocalFileUri() {
+        runCatching {
+            val uri = Uri.parse(this)
+            if (uri.scheme == "file") {
+                uri.path?.let(::File)?.delete()
+            }
+        }
+    }
+
+    private val STOP_WORDS =
+        setOf(
+            "the",
+            "and",
+            "feat",
+            "ft",
+            "with",
+            "remaster",
+            "remastered",
+            "version",
+            "explicit",
+            "clean",
+            "audio",
+            "official",
+        )
+
+    private val VERSION_TOKENS =
+        setOf(
+            "remix",
+            "mix",
+            "edit",
+            "acoustic",
+            "sped",
+            "slowed",
+            "nightcore",
+            "karaoke",
+        )
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
@@ -62,6 +62,7 @@ import moe.rukamori.archivetune.ui.screens.settings.HiddenPlaylistsScreen
 import moe.rukamori.archivetune.ui.screens.settings.IconScreen
 import moe.rukamori.archivetune.ui.screens.settings.IntegrationScreen
 import moe.rukamori.archivetune.ui.screens.settings.InternetSettings
+import moe.rukamori.archivetune.ui.screens.settings.TidalSettings
 import moe.rukamori.archivetune.ui.screens.settings.LastFMSettings
 import moe.rukamori.archivetune.ui.screens.settings.LogcatScreen
 import moe.rukamori.archivetune.ui.screens.settings.LyricsAnimationSettings
@@ -416,6 +417,9 @@ fun NavGraphBuilder.navigationBuilder(
     }
     composable("settings/integration") {
         IntegrationScreen(navController)
+    }
+    composable("settings/tidal") {
+        TidalSettings(navController)
     }
     composable("settings/ai_integration") {
         AiIntegrationSettings(navController)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/IntegrationScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/IntegrationScreen.kt
@@ -86,6 +86,19 @@ fun IntegrationScreen(navController: NavController) {
                 }
             }
 
+            PreferenceGroup(title = stringResource(R.string.music_sources)) {
+                item {
+                    PreferenceEntry(
+                        title = { Text(stringResource(R.string.tidal_integration)) },
+                        description = stringResource(R.string.tidal_integration_description),
+                        icon = { Icon(painterResource(R.drawable.provider_tidal), null) },
+                        onClick = {
+                            navController.navigate("settings/tidal")
+                        },
+                    )
+                }
+            }
+
             PreferenceGroup(title = stringResource(R.string.scrobbling)) {
                 item {
                     PreferenceEntry(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/TidalSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/TidalSettings.kt
@@ -1,0 +1,187 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ *
+ * Tidal music source integration settings.
+ * Ported from MetroFuse (github.com/956tris/MetroFuse) under GPL-3.0.
+ */
+
+package moe.rukamori.archivetune.ui.screens.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavController
+import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
+import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.constants.TidalAccountNameKey
+import moe.rukamori.archivetune.constants.TidalAnimatedCoversEnabledKey
+import moe.rukamori.archivetune.constants.TidalArtworkFallbackEnabledKey
+import moe.rukamori.archivetune.constants.TidalAudioQuality
+import moe.rukamori.archivetune.constants.TidalAudioQualityKey
+import moe.rukamori.archivetune.constants.TidalCookieKey
+import moe.rukamori.archivetune.constants.TidalEnabledKey
+import moe.rukamori.archivetune.ui.component.EditTextPreference
+import moe.rukamori.archivetune.ui.component.EnumListPreference
+import moe.rukamori.archivetune.ui.component.IconButton
+import moe.rukamori.archivetune.ui.component.InfoLabel
+import moe.rukamori.archivetune.ui.component.PreferenceEntry
+import moe.rukamori.archivetune.ui.component.PreferenceGroup
+import moe.rukamori.archivetune.ui.component.SwitchPreference
+import moe.rukamori.archivetune.ui.utils.backToMain
+import moe.rukamori.archivetune.utils.rememberEnumPreference
+import moe.rukamori.archivetune.utils.rememberPreference
+import moe.rukamori.archivetune.utils.tidal.isTidalCookieConfigured
+import moe.rukamori.archivetune.utils.tidal.normalizeTidalCookieInput
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TidalSettings(navController: NavController) {
+    val (tidalEnabled, onTidalEnabledChange) = rememberPreference(TidalEnabledKey, false)
+    val (audioQuality, onAudioQualityChange) =
+        rememberEnumPreference(TidalAudioQualityKey, TidalAudioQuality.FLAC)
+    val (artworkFallback, onArtworkFallbackChange) =
+        rememberPreference(TidalArtworkFallbackEnabledKey, true)
+    val (animatedCovers, onAnimatedCoversChange) =
+        rememberPreference(TidalAnimatedCoversEnabledKey, false)
+    val (tidalCookie, onTidalCookieChange) = rememberPreference(TidalCookieKey, "")
+    val accountName by rememberPreference(TidalAccountNameKey, "")
+
+    val accountConfigured = tidalCookie.isNotBlank() && isTidalCookieConfigured(tidalCookie)
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.tidal_integration)) },
+                navigationIcon = {
+                    IconButton(
+                        onClick = navController::navigateUp,
+                        onLongClick = navController::backToMain,
+                    ) {
+                        Icon(
+                            painterResource(R.drawable.arrow_back),
+                            contentDescription = null,
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        val topPadding = innerPadding.calculateTopPadding()
+
+        Column(
+            Modifier
+                .padding(top = topPadding)
+                .windowInsetsPadding(
+                    LocalPlayerAwareWindowInsets.current.only(
+                        WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
+                    ),
+                )
+                .verticalScroll(rememberScrollState())
+                .padding(bottom = SettingsDimensions.ScreenBottomPadding),
+        ) {
+            PreferenceGroup(title = stringResource(R.string.general)) {
+                item {
+                    SwitchPreference(
+                        title = { Text(stringResource(R.string.tidal_enable)) },
+                        description = stringResource(R.string.tidal_enable_description),
+                        icon = { Icon(painterResource(R.drawable.provider_tidal), null) },
+                        checked = tidalEnabled,
+                        onCheckedChange = onTidalEnabledChange,
+                    )
+                }
+
+                item {
+                    EnumListPreference(
+                        title = { Text(stringResource(R.string.tidal_audio_quality)) },
+                        icon = { Icon(painterResource(R.drawable.play), null) },
+                        selectedValue = audioQuality,
+                        onValueSelected = onAudioQualityChange,
+                        isEnabled = tidalEnabled,
+                        valueText = { quality ->
+                            when (quality) {
+                                TidalAudioQuality.AAC_320 -> stringResource(R.string.tidal_quality_aac_320)
+                                TidalAudioQuality.FLAC -> stringResource(R.string.tidal_quality_flac)
+                                TidalAudioQuality.HI_RES_LOSSLESS -> stringResource(R.string.tidal_quality_hires)
+                            }
+                        },
+                    )
+                }
+            }
+
+            PreferenceGroup(title = stringResource(R.string.tidal_artwork)) {
+                item {
+                    SwitchPreference(
+                        title = { Text(stringResource(R.string.tidal_artwork_fallback)) },
+                        description = stringResource(R.string.tidal_artwork_fallback_description),
+                        checked = artworkFallback,
+                        onCheckedChange = onArtworkFallbackChange,
+                        isEnabled = tidalEnabled,
+                    )
+                }
+
+                item {
+                    SwitchPreference(
+                        title = { Text(stringResource(R.string.tidal_animated_covers)) },
+                        description = stringResource(R.string.tidal_animated_covers_description),
+                        checked = animatedCovers,
+                        onCheckedChange = onAnimatedCoversChange,
+                        isEnabled = tidalEnabled,
+                    )
+                }
+            }
+
+            PreferenceGroup(title = stringResource(R.string.tidal_account)) {
+                item {
+                    InfoLabel(text = stringResource(R.string.tidal_account_description))
+                }
+
+                item {
+                    EditTextPreference(
+                        title = {
+                            Text(
+                                if (accountConfigured) {
+                                    stringResource(R.string.tidal_account_connected, accountName.ifBlank { "Tidal" })
+                                } else {
+                                    stringResource(R.string.tidal_set_cookie)
+                                },
+                            )
+                        },
+                        icon = { Icon(painterResource(R.drawable.token), null) },
+                        value = tidalCookie,
+                        isInputValid = { normalizeTidalCookieInput(it) != null },
+                        onValueChange = { raw ->
+                            onTidalCookieChange(normalizeTidalCookieInput(raw) ?: "")
+                        },
+                    )
+                }
+
+                if (accountConfigured) {
+                    item {
+                        PreferenceEntry(
+                            title = { Text(stringResource(R.string.tidal_disconnect)) },
+                            icon = { Icon(painterResource(R.drawable.logout), null) },
+                            onClick = { onTidalCookieChange("") },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/utils/tidal/TidalCookieUtils.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/utils/tidal/TidalCookieUtils.kt
@@ -1,0 +1,188 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package moe.rukamori.archivetune.utils.tidal
+
+import java.net.URLDecoder
+
+fun normalizeTidalCookieInput(input: String): String? {
+    val trimmedInput =
+        input
+            .trim()
+            .removePrefix("Cookie:")
+            .removePrefix("cookie:")
+            .trim()
+            .trim(';')
+    if (trimmedInput.isBlank()) return null
+
+    return mergeTidalCookieInputs(listOf(trimmedInput))
+}
+
+fun isTidalCookieConfigured(value: String): Boolean = extractTidalRefreshToken(value) != null
+
+fun mergeTidalCookieInputs(inputs: Iterable<String>): String? {
+    val candidates =
+        inputs
+            .flatMap(::tidalAuthCandidates)
+            .filter { it.isNotBlank() }
+
+    val refreshToken = candidates.firstNotNullOfOrNull(::extractTidalRefreshToken)
+    val accessToken = candidates.firstNotNullOfOrNull(::extractTidalAccessToken)
+
+    if (refreshToken.isNullOrBlank() && accessToken.isNullOrBlank()) {
+        return null
+    }
+
+    val cookies = linkedMapOf<String, String>()
+    candidates
+        .flatMap(::parseCookiePairs)
+        .forEach { pair ->
+            cookies[pair.name] = pair.value
+        }
+
+    val ordered = linkedMapOf<String, String>()
+    refreshToken?.let { ordered["refresh_token"] = it }
+    accessToken?.let { ordered["access_token"] = it }
+    cookies.forEach { (name, value) ->
+        ordered.putIfAbsent(name, value)
+    }
+
+    return ordered.entries.joinToString("; ") { (name, value) -> "$name=$value" }
+}
+
+fun extractTidalRefreshToken(input: String): String? {
+    tidalAuthCandidates(input).forEach { candidate ->
+        RefreshTokenRegexes.forEach { regex ->
+            regex.find(candidate)?.groupValues?.getOrNull(1)?.trim()?.trim('"')?.takeIf { it.isNotBlank() }?.let {
+                return it
+            }
+        }
+    }
+
+    return input.trim()
+        .takeIf { value ->
+            value.length >= 24 &&
+                !value.contains(';') &&
+                !value.contains('=') &&
+                !value.contains('\n') &&
+                !value.contains('\r') &&
+                !value.contains('{') &&
+                !value.contains(' ') &&
+                value.count { it == '.' } != 2
+        }
+}
+
+fun extractTidalAccessToken(input: String): String? {
+    tidalAuthCandidates(input).forEach { candidate ->
+        AccessTokenRegexes.forEach { regex ->
+            regex.find(candidate)?.groupValues?.getOrNull(1)?.trim()?.trim('"')?.takeIf { it.isNotBlank() }?.let {
+                return it
+            }
+        }
+        JwtTokenRegex.find(candidate)?.value?.takeIf { it.isNotBlank() }?.let {
+            return it
+        }
+    }
+
+    return input.trim()
+        .takeIf { value ->
+            value.length >= 80 &&
+                value.count { it == '.' } == 2 &&
+                !value.contains(';') &&
+                !value.contains('=') &&
+                !value.contains('\n') &&
+                !value.contains('\r') &&
+                !value.contains('{') &&
+                !value.contains(' ')
+        }
+}
+
+private data class TidalCookiePair(
+    val name: String,
+    val value: String,
+)
+
+private fun tidalAuthCandidates(input: String): List<String> {
+    val trimmed =
+        input
+            .trim()
+            .removePrefix("Cookie:")
+            .removePrefix("cookie:")
+            .trim()
+            .trim(';')
+    if (trimmed.isBlank()) return emptyList()
+
+    return listOfNotNull(
+        trimmed,
+        trimmed.replace("\\\"", "\"").replace("\\\\", "\\"),
+        trimmed.replace("\\u0022", "\""),
+        runCatching { URLDecoder.decode(trimmed, Charsets.UTF_8.name()) }.getOrNull(),
+    ).distinct()
+}
+
+private fun parseCookiePairs(input: String): List<TidalCookiePair> {
+    val header =
+        input
+            .trim()
+            .removePrefix("Cookie:")
+            .removePrefix("cookie:")
+            .trim()
+            .trim(';')
+    if (header.isBlank()) return emptyList()
+
+    return header
+        .split(';', '\n', '\r')
+        .mapNotNull { part ->
+            val trimmed = part.trim()
+            val separator = trimmed.indexOf('=')
+            if (separator <= 0) return@mapNotNull null
+
+            val name = trimmed.substring(0, separator).trim()
+            val value =
+                trimmed
+                    .substring(separator + 1)
+                    .trim()
+                    .trim('"')
+
+            TidalCookiePair(
+                name = name,
+                value = value,
+            ).takeIf {
+                it.name.matches(CookieNameRegex) &&
+                    it.name.lowercase() !in CookieAttributeNames &&
+                    it.value.isNotBlank()
+            }
+        }
+}
+
+private val RefreshTokenRegexes =
+    listOf(
+        Regex(""""refresh_token"\s*:\s*"([^"]+)""""),
+        Regex(""""refreshToken"\s*:\s*"([^"]+)""""),
+        Regex("""(?:^|[?&\s;])refresh_token=([^&;\s]+)"""),
+        Regex("""(?:^|[?&\s;])refreshToken=([^&;\s]+)"""),
+    )
+
+private val AccessTokenRegexes =
+    listOf(
+        Regex(""""access_token"\s*:\s*"([^"]+)""""),
+        Regex(""""accessToken"\s*:\s*"([^"]+)""""),
+        Regex("""(?:^|[?&\s;])access_token=([^&;\s]+)"""),
+        Regex("""(?:^|[?&\s;])accessToken=([^&;\s]+)"""),
+    )
+
+private val JwtTokenRegex = Regex("""eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+""")
+private val CookieNameRegex = Regex("^[!#$%&'*+.^_`|~0-9A-Za-z-]+$")
+private val CookieAttributeNames =
+    setOf(
+        "domain",
+        "expires",
+        "max-age",
+        "path",
+        "priority",
+        "samesite",
+        "secure",
+        "httponly",
+    )

--- a/app/src/main/res/drawable/provider_tidal.xml
+++ b/app/src/main/res/drawable/provider_tidal.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M5.5,4.5l3.5,3.5 -3.5,3.5L2,8zM12,4.5l3.5,3.5 -3.5,3.5L8.5,8zM18.5,4.5L22,8l-3.5,3.5L15,8zM8.75,11.25l3.25,3.25 -3.25,3.25 -3.25,-3.25zM15.25,11.25l3.25,3.25 -3.25,3.25 -3.25,-3.25z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -638,6 +638,26 @@
     <string name="backup_create_failed">Couldn\'t create backup</string>
     <string name="restore_success">Backup restored successfully</string>
     <string name="restore_failed">Failed to restore backup</string>
+    <!-- Tidal music source integration -->
+    <string name="music_sources">Music Sources</string>
+    <string name="tidal_integration">Tidal</string>
+    <string name="tidal_integration_description">Stream lossless audio from Tidal</string>
+    <string name="tidal_enable">Enable Tidal source</string>
+    <string name="tidal_enable_description">Route playback through Tidal\'s lossless resolver when a matching track is found</string>
+    <string name="tidal_audio_quality">Audio quality</string>
+    <string name="tidal_quality_aac_320">AAC 320 kbps</string>
+    <string name="tidal_quality_flac">FLAC (Lossless)</string>
+    <string name="tidal_quality_hires">Hi-Res Lossless</string>
+    <string name="tidal_artwork">Artwork</string>
+    <string name="tidal_artwork_fallback">Use Tidal artwork</string>
+    <string name="tidal_artwork_fallback_description">Fall back to Tidal cover art when none is available</string>
+    <string name="tidal_animated_covers">Animated covers</string>
+    <string name="tidal_animated_covers_description">Show Tidal video/canvas covers when available</string>
+    <string name="tidal_account">Account (optional)</string>
+    <string name="tidal_account_description">Playback works without signing in. Optionally paste your Tidal session cookie to improve matching and access your library.</string>
+    <string name="tidal_set_cookie">Set Tidal cookie</string>
+    <string name="tidal_account_connected">Connected: %1$s</string>
+    <string name="tidal_disconnect">Disconnect Tidal account</string>
     <string name="discord_integration">Discord Integration</string>
     <string name="account_integrations_summary">Discord, Last.fm, Libre.fm, ListenBrainz</string>
     <string name="discord_login_description">Connect your Discord account with OAuth so ArchiveTune can publish Rich Presence.</string>


### PR DESCRIPTION
## Summary

Adds **Tidal** as a lossless music source in ArchiveTune, ported from [MetroFuse](https://github.com/956tris/MetroFuse). Settings live under **Settings → Integration → Music Sources → Tidal**, as requested.

## What's included

- **`tidal/TidalAudioProvider.kt`** — Tidal stream resolver (FLAC / Hi-Res via public resolver endpoints)
- **`utils/tidal/TidalCookieUtils.kt`** — Tidal session/cookie parsing (optional account feature)
- **`constants/PreferenceKeys.kt`** — Tidal preference keys + `TidalAudioQuality` enum
- **`playback/MusicService.kt`** — Tidal resolution wired into the existing `resolvePlaybackDataSpec` / `ResolvingDataSource` seam; falls back to YouTube when no Tidal match is found
- **`ui/screens/settings/TidalSettings.kt`** — settings screen: enable toggle, audio quality, artwork/animated cover options, optional account cookie
- **`ui/screens/settings/IntegrationScreen.kt`** — "Music Sources → Tidal" entry
- **`ui/screens/NavigationBuilder.kt`** — registers `settings/tidal` route
- **`res/values/strings.xml`** + **`res/drawable/provider_tidal.xml`** — strings and icon

## Behavior notes

- Playback works **without signing in** (public resolver endpoints); the account cookie is optional and only improves matching/library access.
- Tidal is only used when the source is enabled and a matching track is found — otherwise playback uses the normal YouTube path.

## Not yet included / caveats

- **Not compile-verified.** This was produced outside an Android build environment — please run `./gradlew assembleDebug` and address any minor issues.
- Scope covers the music source + full playback + settings, **not** Tidal library/playlist browsing.

Ported from MetroFuse under **GPL-3.0**.
