### PR TITLE
feat(tidal): fix playback cache conflict, add instance management + account login

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -740,6 +740,21 @@ val TidalArtworkFallbackEnabledKey = booleanPreferencesKey("tidalArtworkFallback
 val TidalAnimatedCoversEnabledKey = booleanPreferencesKey("tidalAnimatedCoversEnabled")
 val TidalAccountNameKey = stringPreferencesKey("tidal_account_name")
 
+// Newline-separated list of user-configured HiFi/QQDL instance base URLs. Empty = use defaults.
+val TidalInstancesKey = stringPreferencesKey("tidalInstances")
+
+// Tidal account login (device/OAuth) + subscription state.
+val TidalAccessTokenKey = stringPreferencesKey("tidalAccessToken")
+val TidalRefreshTokenKey = stringPreferencesKey("tidalRefreshToken")
+val TidalTokenExpiryKey = longPreferencesKey("tidalTokenExpiry")
+val TidalSubscriptionKey = stringPreferencesKey("tidalSubscription")
+
+enum class TidalSubscriptionStatus {
+    UNKNOWN,
+    PREMIUM,
+    FREE,
+}
+
 enum class TidalAudioQuality {
     AAC_320,
     FLAC,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -175,6 +175,7 @@ import moe.rukamori.archivetune.constants.PlayerStreamClientKey
 import moe.rukamori.archivetune.constants.TidalAudioQuality
 import moe.rukamori.archivetune.constants.TidalAudioQualityKey
 import moe.rukamori.archivetune.constants.TidalEnabledKey
+import moe.rukamori.archivetune.constants.TidalInstancesKey
 import moe.rukamori.archivetune.tidal.TidalAudioProvider
 import moe.rukamori.archivetune.constants.PlayerVolumeKey
 import moe.rukamori.archivetune.constants.RepeatModeKey
@@ -744,6 +745,8 @@ class MusicService :
     private val togetherParticipantNames = ConcurrentHashMap<String, String>()
     private var lastTogetherNoticeAtElapsedMs: Long = 0L
     private var lastTogetherNoticeKey: String? = null
+    private var lastTidalNoticeAtElapsedMs: Long = 0L
+    private var lastTidalNoticeKey: String? = null
 
     private data class TogetherPendingGuestControl(
         val desiredIsPlaying: Boolean? = null,
@@ -6918,6 +6921,13 @@ class MusicService :
         return runCatching { TidalAudioQuality.valueOf(stored) }.getOrDefault(TidalAudioQuality.FLAC)
     }
 
+    private fun parseTidalInstances(): List<String> =
+        dataStore
+            .get(TidalInstancesKey, "")
+            .split('\n')
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+
     /**
      * Attempts to resolve the current media item as a Tidal stream. Returns a [DataSpec]
      * pointing at a Tidal (FLAC/Hi-Res) stream when the Tidal source is enabled and a match
@@ -6932,6 +6942,9 @@ class MusicService :
     ): DataSpec? {
         if (!dataStore.get(TidalEnabledKey, false)) return null
         if (mediaId.isLocalMediaId()) return null
+
+        // Apply the user-configured HiFi instance list (empty falls back to built-in defaults).
+        TidalAudioProvider.setInstances(parseTidalInstances())
 
         val song =
             runCatching {
@@ -6978,11 +6991,53 @@ class MusicService :
                 )
             }.onFailure { error ->
                 Timber.tag("MusicService").w(error, "TIDAL stream resolution failed for %s", mediaId)
-            }.getOrNull() ?: return null
+            }.getOrNull()
+
+        if (resolved == null) {
+            // Tidal is the intended source but no instance could resolve this track
+            // (all instances down, rate-limited, or no confident match). Let the caller
+            // fall through to YouTube and surface a one-off notice so the user knows why.
+            showTidalNotice(getString(R.string.tidal_playback_fell_back), key = "tidal_fallback")
+            return null
+        }
 
         Timber.tag("MusicService").i("Using TIDAL stream for %s: %s", mediaId, resolved.label)
-        resolved.contentLength?.takeIf { it > 0L }?.let { contentLengthCache[mediaId] = it }
-        return dataSpec.withUri(resolved.mediaUri.toUri())
+        // Cache Tidal bytes under a dedicated key so they never collide with the YouTube
+        // stream for the same media id (different codec, bitrate and content length).
+        val tidalCacheKey = tidalCacheKey(mediaId)
+        resolved.contentLength?.takeIf { it > 0L }?.let { contentLengthCache[tidalCacheKey] = it }
+        // The stored YouTube loudness data does not describe the Tidal FLAC stream, so use a
+        // neutral normalization factor rather than mis-applying the YouTube value.
+        audioNormalizationFactorCache[mediaId] = 1f
+        return dataSpec
+            .buildUpon()
+            .setUri(resolved.mediaUri.toUri())
+            .setKey(tidalCacheKey)
+            .build()
+    }
+
+    private fun tidalCacheKey(mediaId: String): String = "$TIDAL_CACHE_KEY_PREFIX$mediaId"
+
+    /**
+     * Cheap check (no network) for whether the Tidal source should be preferred for [mediaId].
+     * Used to gate the ephemeral YouTube player-cache short-circuit so toggling Tidal on takes
+     * effect immediately instead of replaying previously cached YouTube bytes.
+     */
+    private fun tidalSourceApplies(mediaId: String): Boolean =
+        dataStore.get(TidalEnabledKey, false) && !mediaId.isLocalMediaId()
+
+    private fun showTidalNotice(
+        message: String,
+        key: String? = null,
+    ) {
+        val now = android.os.SystemClock.elapsedRealtime()
+        val normalizedKey = key ?: message
+        if (normalizedKey == lastTidalNoticeKey && now - lastTidalNoticeAtElapsedMs < 4000L) return
+        lastTidalNoticeKey = normalizedKey
+        lastTidalNoticeAtElapsedMs = now
+        scope.launch(SilentHandler) {
+            Toast.makeText(this@MusicService, message, Toast.LENGTH_SHORT).show()
+        }
     }
 
     private fun resolvePlaybackDataSpec(
@@ -7013,11 +7068,19 @@ class MusicService :
 
         knownContentLength?.takeIf { it > 0L }?.let { contentLengthCache[mediaId] = it }
 
+        // When the Tidal source is enabled for this track, the ephemeral YouTube player cache
+        // must not short-circuit playback (otherwise toggling Tidal on would keep replaying the
+        // previously cached YouTube bytes). Persistent downloads still win so offline playback
+        // and explicit downloads are unaffected.
+        val tidalApplies = tidalSourceApplies(mediaId)
+        val allowPlayerCacheShortCircuit = !tidalApplies
+
         if (allowCacheShortCircuit) {
             resolveCachedDataSpec(
                 dataSpec = dataSpec,
                 mediaId = mediaId,
                 knownContentLength = knownContentLength,
+                includePlayerCache = allowPlayerCacheShortCircuit,
             )?.let { cachedDataSpec ->
                 scope.launch(Dispatchers.IO) { recoverSong(mediaId) }
                 return cachedDataSpec
@@ -7036,7 +7099,10 @@ class MusicService :
         if (allowCacheShortCircuit && requiredCachedLength != null) {
             val isFullyCached =
                 downloadCache.isCached(mediaId, dataSpec.position, requiredCachedLength) ||
-                    playerCache.isCached(mediaId, dataSpec.position, requiredCachedLength)
+                    (
+                        allowPlayerCacheShortCircuit &&
+                            playerCache.isCached(mediaId, dataSpec.position, requiredCachedLength)
+                    )
             if (isFullyCached) {
                 scope.launch(Dispatchers.IO) { recoverSong(mediaId) }
                 return dataSpec
@@ -7356,6 +7422,7 @@ class MusicService :
         dataSpec: DataSpec,
         mediaId: String,
         knownContentLength: Long?,
+        includePlayerCache: Boolean = true,
     ): DataSpec? {
         val requestedLength =
             when {
@@ -7377,6 +7444,7 @@ class MusicService :
                 mediaId = mediaId,
                 position = dataSpec.position,
                 requestedLength = requestedLength,
+                includePlayerCache = includePlayerCache,
             )
 
         if (cachedLength < requestedLength) return null
@@ -7388,13 +7456,20 @@ class MusicService :
         mediaId: String,
         position: Long,
         requestedLength: Long,
+        includePlayerCache: Boolean = true,
     ): Long {
         val targetEnd = position.saturatingAdd(requestedLength)
         var cursor = position
+        val playerCacheSpans =
+            if (includePlayerCache) {
+                runCatching { playerCache.getCachedSpans(mediaId).toList() }.getOrNull().orEmpty()
+            } else {
+                emptyList()
+            }
         val spans =
             (
                 runCatching { downloadCache.getCachedSpans(mediaId).toList() }.getOrNull().orEmpty() +
-                    runCatching { playerCache.getCachedSpans(mediaId).toList() }.getOrNull().orEmpty()
+                    playerCacheSpans
             ).asSequence()
                 .filter { span -> span.position.saturatingAdd(span.length) > position }
                 .sortedBy { span -> span.position }
@@ -8228,6 +8303,10 @@ class MusicService :
         const val ROOT = "root"
         const val HOME = "home"
         const val HOME_QUICK_PICKS = "home_quick_picks"
+
+        // Prefix for the dedicated player-cache key used by Tidal streams so their bytes never
+        // collide with the YouTube stream cached under the bare media id.
+        private const val TIDAL_CACHE_KEY_PREFIX = "tidal:"
         const val HOME_FORGOTTEN_FAVORITES = "home_forgotten_favorites"
         const val HOME_KEEP_LISTENING = "home_keep_listening"
         const val HOME_SUGGESTED_SONGS = "home_suggested_songs"

--- a/app/src/main/kotlin/moe/rukamori/archivetune/tidal/TidalAccountManager.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/tidal/TidalAccountManager.kt
@@ -1,0 +1,247 @@
+/**
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ *
+ * Tidal account login via the OAuth 2.0 Device Authorization Grant, plus subscription
+ * (HiFi/Premium) detection. Signing in is optional: playback itself is served by the public
+ * HiFi instances configured in [TidalAudioProvider]. Logging in only lets the app tell the user
+ * whether their own Tidal account is a paid tier, and warn when it is not.
+ */
+
+package moe.rukamori.archivetune.tidal
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import okhttp3.FormBody
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONObject
+import timber.log.Timber
+import java.util.concurrent.TimeUnit
+
+object TidalAccountManager {
+    // Well-known public Tidal "TV/device" OAuth client used by open-source Tidal tooling for the
+    // device authorization grant. These are not secret user credentials.
+    private const val CLIENT_ID = "zU4XHVVkc2tDPo4t"
+    private const val CLIENT_SECRET = "VJKhDFqJPqvsPVNBV6ukXTJmwlvbttP7wlMlrc72se4="
+
+    private const val DEVICE_AUTH_ENDPOINT = "https://auth.tidal.com/v1/oauth2/device_authorization"
+    private const val TOKEN_ENDPOINT = "https://auth.tidal.com/v1/oauth2/token"
+    private const val API_BASE = "https://api.tidal.com/v1"
+    private const val SCOPE = "r_usr+w_usr+w_sub"
+    private const val COUNTRY_CODE = "US"
+    private const val DEVICE_GRANT = "urn:ietf:params:oauth:grant-type:device_code"
+
+    private val client =
+        OkHttpClient
+            .Builder()
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(15, TimeUnit.SECONDS)
+            .callTimeout(20, TimeUnit.SECONDS)
+            .build()
+
+    /** Details returned when a device login is initiated; shown to the user to authorize. */
+    data class DeviceAuthorization(
+        val deviceCode: String,
+        val userCode: String,
+        val verificationUri: String,
+        val verificationUriComplete: String,
+        val expiresInSeconds: Int,
+        val intervalSeconds: Int,
+    )
+
+    /** Result of a successful token exchange. [expiresAtMillis] is an absolute epoch time. */
+    data class TokenResult(
+        val accessToken: String,
+        val refreshToken: String?,
+        val expiresAtMillis: Long,
+        val userId: Long?,
+        val username: String?,
+    )
+
+    /** Subscription tier resolved from the Tidal API. */
+    enum class Subscription {
+        UNKNOWN,
+        PREMIUM,
+        FREE,
+    }
+
+    sealed interface PollResult {
+        data class Success(val token: TokenResult) : PollResult
+
+        /** Authorization still pending; keep polling. */
+        data object Pending : PollResult
+
+        /** Slow down polling (server returned slow_down). */
+        data object SlowDown : PollResult
+
+        /** Terminal failure (expired, denied, or network). */
+        data class Failure(val reason: String) : PollResult
+    }
+
+    /**
+     * Step 1: request a device + user code. Returns null on failure (e.g. no network).
+     * Runs on IO.
+     */
+    suspend fun requestDeviceAuthorization(): DeviceAuthorization? =
+        withContext(Dispatchers.IO) {
+            val body =
+                FormBody
+                    .Builder()
+                    .add("client_id", CLIENT_ID)
+                    .add("scope", SCOPE)
+                    .build()
+            val request =
+                Request
+                    .Builder()
+                    .url(DEVICE_AUTH_ENDPOINT)
+                    .post(body)
+                    .build()
+            runCatching {
+                client.newCall(request).execute().use { response ->
+                    val payload = response.body?.string().orEmpty()
+                    if (!response.isSuccessful) {
+                        Timber.tag("TidalAccount").w("device_authorization failed: %d %s", response.code, payload)
+                        return@use null
+                    }
+                    val json = JSONObject(payload)
+                    DeviceAuthorization(
+                        deviceCode = json.getString("deviceCode"),
+                        userCode = json.getString("userCode"),
+                        verificationUri = json.optString("verificationUri", "link.tidal.com"),
+                        verificationUriComplete =
+                            json.optString(
+                                "verificationUriComplete",
+                                "https://${json.optString("verificationUri", "link.tidal.com")}/${json.optString("userCode")}",
+                            ),
+                        expiresInSeconds = json.optInt("expiresIn", 300),
+                        intervalSeconds = json.optInt("interval", 2),
+                    )
+                }
+            }.getOrElse {
+                Timber.tag("TidalAccount").w(it, "device_authorization error")
+                null
+            }
+        }
+
+    /** Step 2 (single attempt): exchange the device code for tokens. Runs on IO. */
+    suspend fun pollForToken(deviceCode: String): PollResult =
+        withContext(Dispatchers.IO) {
+            val body =
+                FormBody
+                    .Builder()
+                    .add("client_id", CLIENT_ID)
+                    .add("client_secret", CLIENT_SECRET)
+                    .add("device_code", deviceCode)
+                    .add("grant_type", DEVICE_GRANT)
+                    .add("scope", SCOPE)
+                    .build()
+            val request =
+                Request
+                    .Builder()
+                    .url(TOKEN_ENDPOINT)
+                    .post(body)
+                    .build()
+            runCatching {
+                client.newCall(request).execute().use { response ->
+                    val payload = response.body?.string().orEmpty()
+                    val json = runCatching { JSONObject(payload) }.getOrNull()
+                    if (response.isSuccessful && json != null) {
+                        val user = json.optJSONObject("user")
+                        return@use PollResult.Success(
+                            TokenResult(
+                                accessToken = json.getString("access_token"),
+                                refreshToken = json.optString("refresh_token").ifBlank { null },
+                                expiresAtMillis =
+                                    System.currentTimeMillis() +
+                                        (json.optLong("expires_in", 3600L) * 1000L),
+                                userId = user?.optLong("userId")?.takeIf { it > 0 },
+                                username = user?.optString("username")?.ifBlank { null },
+                            ),
+                        )
+                    }
+                    when (json?.optString("error")) {
+                        "authorization_pending" -> PollResult.Pending
+                        "slow_down" -> PollResult.SlowDown
+                        "expired_token" -> PollResult.Failure("expired")
+                        "access_denied" -> PollResult.Failure("denied")
+                        else -> PollResult.Failure(json?.optString("error").orEmpty().ifBlank { "http_${response.code}" })
+                    }
+                }
+            }.getOrElse {
+                Timber.tag("TidalAccount").w(it, "token poll error")
+                PollResult.Pending // treat transient network errors as retryable
+            }
+        }
+
+    /**
+     * Convenience: run the full device flow, polling until success/failure or [onCode]-provided
+     * authorization expires. [onCode] is invoked once with the authorization so the UI can show
+     * the code and link. Returns the token or null on failure.
+     */
+    suspend fun login(onCode: suspend (DeviceAuthorization) -> Unit): TokenResult? {
+        val auth = requestDeviceAuthorization() ?: return null
+        onCode(auth)
+        var intervalMs = auth.intervalSeconds.coerceAtLeast(1) * 1000L
+        val deadline = System.currentTimeMillis() + auth.expiresInSeconds * 1000L
+        while (System.currentTimeMillis() < deadline) {
+            delay(intervalMs)
+            when (val result = pollForToken(auth.deviceCode)) {
+                is PollResult.Success -> return result.token
+                is PollResult.Pending -> Unit
+                is PollResult.SlowDown -> intervalMs += 2000L
+                is PollResult.Failure -> {
+                    Timber.tag("TidalAccount").w("login failed: %s", result.reason)
+                    return null
+                }
+            }
+        }
+        return null
+    }
+
+    /**
+     * Resolves the subscription tier for the signed-in account. Any paid tier (HIFI, PREMIUM,
+     * PREMIUM_PLUS, HIFI_PLUS, etc.) maps to [Subscription.PREMIUM]; an explicit free tier maps to
+     * [Subscription.FREE]; anything indeterminate is [Subscription.UNKNOWN]. Runs on IO.
+     */
+    suspend fun fetchSubscription(
+        accessToken: String,
+        userId: Long,
+    ): Subscription =
+        withContext(Dispatchers.IO) {
+            val request =
+                Request
+                    .Builder()
+                    .url("$API_BASE/users/$userId/subscription?countryCode=$COUNTRY_CODE")
+                    .header("Authorization", "Bearer $accessToken")
+                    .get()
+                    .build()
+            runCatching {
+                client.newCall(request).execute().use { response ->
+                    val payload = response.body?.string().orEmpty()
+                    if (!response.isSuccessful) {
+                        Timber.tag("TidalAccount").w("subscription lookup failed: %d", response.code)
+                        return@use Subscription.UNKNOWN
+                    }
+                    val json = JSONObject(payload)
+                    val type =
+                        json
+                            .optJSONObject("subscription")
+                            ?.optString("type")
+                            ?.uppercase()
+                            .orEmpty()
+                    when {
+                        type.isBlank() -> Subscription.UNKNOWN
+                        type.contains("FREE") -> Subscription.FREE
+                        // HIFI, HIFI_PLUS, PREMIUM, PREMIUM_PLUS, etc.
+                        else -> Subscription.PREMIUM
+                    }
+                }
+            }.getOrElse {
+                Timber.tag("TidalAccount").w(it, "subscription lookup error")
+                Subscription.UNKNOWN
+            }
+        }
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/tidal/TidalAudioProvider.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/tidal/TidalAudioProvider.kt
@@ -57,7 +57,7 @@ object TidalAudioProvider {
     private const val STRONG_MATCH_SCORE = 150
     private const val REJECT_SCORE = -1_000_000
     private val AMAZON_DATE = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'", Locale.US)
-    private val DOWNLOAD_API_ENDPOINTS =
+    private val DEFAULT_DOWNLOAD_API_ENDPOINTS =
         listOf(
             TidalDownloadEndpoint("HiFi is Back v2.7", "https://hifi-isback.peridotclient.com"),
             TidalDownloadEndpoint("Maus QQDL v2.6", "https://maus.qqdl.site"),
@@ -66,6 +66,139 @@ object TidalAudioProvider {
             TidalDownloadEndpoint("Hund QQDL v2.6", "https://hund.qqdl.site"),
             TidalDownloadEndpoint("Wolf QQDL v2.6", "https://wolf.qqdl.site"),
         )
+
+    // Community sources that publish public HiFi/QQDL instance lists. Best-effort only: these
+    // rotate and may disappear, so discovery is allowed to fail and callers keep the manual list.
+    private val INSTANCE_DISCOVERY_SOURCES =
+        listOf(
+            "https://raw.githubusercontent.com/hifi-instances/list/main/instances.json",
+            "https://raw.githubusercontent.com/hifi-instances/list/main/instances.txt",
+        )
+
+    /**
+     * User-configured instance list (base URLs), applied via [setInstances]. When null or empty
+     * the built-in [DEFAULT_DOWNLOAD_API_ENDPOINTS] are used so the source keeps working out of
+     * the box.
+     */
+    @Volatile
+    private var customEndpoints: List<TidalDownloadEndpoint>? = null
+
+    private val activeEndpoints: List<TidalDownloadEndpoint>
+        get() = customEndpoints?.takeIf { it.isNotEmpty() } ?: DEFAULT_DOWNLOAD_API_ENDPOINTS
+
+    /** Base URLs of the built-in default instances, for the settings UI "reset" action. */
+    val defaultInstanceUrls: List<String>
+        get() = DEFAULT_DOWNLOAD_API_ENDPOINTS.map { it.baseUrl }
+
+    /** Base URLs currently in effect (custom list if set, otherwise defaults). */
+    val activeInstanceUrls: List<String>
+        get() = activeEndpoints.map { it.baseUrl }
+
+    /**
+     * Replaces the active instance list. Invalid or duplicate URLs are dropped; if nothing valid
+     * remains the provider reverts to the built-in defaults.
+     */
+    fun setInstances(baseUrls: List<String>) {
+        val seen = LinkedHashSet<String>()
+        val parsed =
+            baseUrls.mapNotNull { raw ->
+                val normalized = normalizeInstanceUrl(raw) ?: return@mapNotNull null
+                if (!seen.add(normalized)) return@mapNotNull null
+                TidalDownloadEndpoint(instanceLabel(normalized), normalized)
+            }
+        customEndpoints = parsed.ifEmpty { null }
+    }
+
+    /** Normalizes an instance URL to `scheme://host[:port]` form, or null if it is not valid. */
+    fun normalizeInstanceUrl(raw: String): String? {
+        val trimmed = raw.trim().trimEnd('/')
+        if (trimmed.isEmpty()) return null
+        val withScheme = if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) trimmed else "https://$trimmed"
+        val url = withScheme.toHttpUrlOrNull() ?: return null
+        if (url.host.isBlank() || !url.host.contains('.')) return null
+        return withScheme
+    }
+
+    private fun instanceLabel(baseUrl: String): String =
+        baseUrl.toHttpUrlOrNull()?.host ?: baseUrl
+
+    /**
+     * Lightweight reachability probe for a single instance. Returns the round-trip latency in
+     * milliseconds when the instance responds, or null when it is unreachable. Runs a blocking
+     * network call, so callers must invoke it off the main thread.
+     */
+    fun checkInstance(baseUrl: String): Long? {
+        val normalized = normalizeInstanceUrl(baseUrl) ?: return null
+        val request =
+            Request
+                .Builder()
+                .url("$normalized/")
+                .header("User-Agent", DOWNLOAD_USER_AGENT)
+                .get()
+                .build()
+        return runCatching {
+            val start = System.currentTimeMillis()
+            healthClient.newCall(request).execute().use { response ->
+                if (response.code in 200..499) System.currentTimeMillis() - start else null
+            }
+        }.getOrNull()
+    }
+
+    /**
+     * Best-effort auto-discovery of additional public instances from community sources. Returns
+     * the list of newly discovered, valid base URLs (may be empty). Never throws; on failure it
+     * simply returns an empty list so the caller can keep the manual list. Runs blocking network
+     * calls, so invoke it off the main thread.
+     */
+    fun discoverInstances(): List<String> {
+        val discovered = LinkedHashSet<String>()
+        for (source in INSTANCE_DISCOVERY_SOURCES) {
+            runCatching {
+                val request =
+                    Request
+                        .Builder()
+                        .url(source)
+                        .header("User-Agent", DOWNLOAD_USER_AGENT)
+                        .get()
+                        .build()
+                healthClient.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) return@use
+                    val body = response.body?.string().orEmpty()
+                    parseDiscoveredInstances(body).forEach { url ->
+                        normalizeInstanceUrl(url)?.let(discovered::add)
+                    }
+                }
+            }
+        }
+        return discovered.toList()
+    }
+
+    /** Parses a discovery payload that is either a JSON array or newline-separated URLs. */
+    private fun parseDiscoveredInstances(body: String): List<String> {
+        val trimmed = body.trim()
+        if (trimmed.isEmpty()) return emptyList()
+        // Try JSON array of strings or objects with a "url"/"host" field.
+        runCatching {
+            val arr = JSONArray(trimmed)
+            return buildList {
+                for (i in 0 until arr.length()) {
+                    when (val item = arr.opt(i)) {
+                        is String -> add(item)
+                        is JSONObject -> {
+                            (item.optString("url").takeIf { it.isNotBlank() }
+                                ?: item.optString("host").takeIf { it.isNotBlank() })
+                                ?.let(::add)
+                        }
+                    }
+                }
+            }
+        }
+        // Fall back to newline / whitespace separated URLs.
+        return trimmed
+            .split('\n', '\r', ' ', ',')
+            .map { it.trim() }
+            .filter { it.isNotEmpty() && !it.startsWith("#") }
+    }
 
     data class Query(
         val mediaId: String,
@@ -219,6 +352,16 @@ object TidalAudioProvider {
             .connectTimeout(8, TimeUnit.SECONDS)
             .readTimeout(20, TimeUnit.SECONDS)
             .callTimeout(25, TimeUnit.SECONDS)
+            .build()
+
+    // Short-timeout client used for instance health checks and discovery so a dead instance
+    // fails fast instead of blocking on the long streaming timeouts above.
+    private val healthClient =
+        OkHttpClient
+            .Builder()
+            .connectTimeout(5, TimeUnit.SECONDS)
+            .readTimeout(5, TimeUnit.SECONDS)
+            .callTimeout(6, TimeUnit.SECONDS)
             .build()
 
     private val trackCache = ConcurrentHashMap<String, CachedTrack>()
@@ -492,7 +635,7 @@ object TidalAudioProvider {
         val now = System.currentTimeMillis()
         searchCache[cacheKey]?.takeIf { it.expiresAtMs > now }?.let { return it.results }
         val parameter = if (exactIsrc) "i" else "s"
-        for (endpoint in DOWNLOAD_API_ENDPOINTS) {
+        for (endpoint in activeEndpoints) {
             val url =
                 endpoint.baseUrl
                     .toHttpUrl()
@@ -713,7 +856,8 @@ object TidalAudioProvider {
         val errors = mutableListOf<String>()
         var rateLimitCount = 0
         var longestRetryAfterMs = 0L
-        for (endpoint in DOWNLOAD_API_ENDPOINTS) {
+        val endpoints = activeEndpoints
+        for (endpoint in endpoints) {
             val result =
                 runCatching {
                     requestDirectFlacFromEndpoint(
@@ -738,7 +882,7 @@ object TidalAudioProvider {
             errors += "${endpoint.name}: ${error.message ?: error.javaClass.simpleName}"
             Timber.tag("TidalAudio").w(error, "TIDAL resolver ${endpoint.name} failed for ${track.trackId}")
         }
-        if (rateLimitCount == DOWNLOAD_API_ENDPOINTS.size && longestRetryAfterMs > 0L) {
+        if (rateLimitCount == endpoints.size && longestRetryAfterMs > 0L) {
             resolverRateLimitedUntilMs = System.currentTimeMillis() + longestRetryAfterMs
             throw TidalRateLimitedException(longestRetryAfterMs)
         }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/TidalSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/TidalSettings.kt
@@ -10,6 +10,9 @@
 
 package moe.rukamori.archivetune.ui.screens.settings
 
+import android.content.Intent
+import android.net.Uri
+import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.only
@@ -24,35 +27,54 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.datastore.preferences.core.edit
 import androidx.navigation.NavController
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.constants.TidalAccessTokenKey
 import moe.rukamori.archivetune.constants.TidalAccountNameKey
 import moe.rukamori.archivetune.constants.TidalAnimatedCoversEnabledKey
 import moe.rukamori.archivetune.constants.TidalArtworkFallbackEnabledKey
 import moe.rukamori.archivetune.constants.TidalAudioQuality
 import moe.rukamori.archivetune.constants.TidalAudioQualityKey
-import moe.rukamori.archivetune.constants.TidalCookieKey
+import moe.rukamori.archivetune.constants.TidalInstancesKey
+import moe.rukamori.archivetune.constants.TidalRefreshTokenKey
+import moe.rukamori.archivetune.constants.TidalSubscriptionKey
+import moe.rukamori.archivetune.constants.TidalSubscriptionStatus
+import moe.rukamori.archivetune.constants.TidalTokenExpiryKey
 import moe.rukamori.archivetune.constants.TidalEnabledKey
-import moe.rukamori.archivetune.ui.component.EditTextPreference
+import moe.rukamori.archivetune.tidal.TidalAccountManager
+import moe.rukamori.archivetune.tidal.TidalAudioProvider
 import moe.rukamori.archivetune.ui.component.EnumListPreference
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.InfoLabel
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
 import moe.rukamori.archivetune.ui.component.PreferenceGroup
 import moe.rukamori.archivetune.ui.component.SwitchPreference
+import moe.rukamori.archivetune.ui.component.TextFieldDialog
 import moe.rukamori.archivetune.ui.utils.backToMain
+import moe.rukamori.archivetune.utils.dataStore
 import moe.rukamori.archivetune.utils.rememberEnumPreference
 import moe.rukamori.archivetune.utils.rememberPreference
-import moe.rukamori.archivetune.utils.tidal.isTidalCookieConfigured
-import moe.rukamori.archivetune.utils.tidal.normalizeTidalCookieInput
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TidalSettings(navController: NavController) {
+    val context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
+
     val (tidalEnabled, onTidalEnabledChange) = rememberPreference(TidalEnabledKey, false)
     val (audioQuality, onAudioQualityChange) =
         rememberEnumPreference(TidalAudioQualityKey, TidalAudioQuality.FLAC)
@@ -60,10 +82,68 @@ fun TidalSettings(navController: NavController) {
         rememberPreference(TidalArtworkFallbackEnabledKey, true)
     val (animatedCovers, onAnimatedCoversChange) =
         rememberPreference(TidalAnimatedCoversEnabledKey, false)
-    val (tidalCookie, onTidalCookieChange) = rememberPreference(TidalCookieKey, "")
-    val accountName by rememberPreference(TidalAccountNameKey, "")
 
-    val accountConfigured = tidalCookie.isNotBlank() && isTidalCookieConfigured(tidalCookie)
+    // Instances stored as a newline-separated string; blank means "use built-in defaults".
+    val (storedInstances, onStoredInstancesChange) = rememberPreference(TidalInstancesKey, "")
+    val accessToken by rememberPreference(TidalAccessTokenKey, "")
+    val accountName by rememberPreference(TidalAccountNameKey, "")
+    val subscriptionRaw by rememberPreference(TidalSubscriptionKey, TidalSubscriptionStatus.UNKNOWN.name)
+
+    val defaults = remember { TidalAudioProvider.defaultInstanceUrls }
+    val effectiveInstances =
+        remember(storedInstances) {
+            storedInstances
+                .split('\n')
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+                .ifEmpty { defaults }
+        }
+
+    fun persistInstances(list: List<String>) {
+        val distinct = list.distinct()
+        onStoredInstancesChange(if (distinct == defaults) "" else distinct.joinToString("\n"))
+    }
+
+    // baseUrl -> health label (null while unchecked)
+    val healthStatus = remember { mutableStateMapOf<String, String>() }
+    var checkingInstances by remember { mutableStateOf(false) }
+    var discovering by remember { mutableStateOf(false) }
+    var showAddDialog by remember { mutableStateOf(false) }
+
+    // Account login state.
+    var loginUserCode by remember { mutableStateOf<String?>(null) }
+    var loginVerificationUri by remember { mutableStateOf<String?>(null) }
+    var loginInProgress by remember { mutableStateOf(false) }
+
+    val subscription =
+        remember(subscriptionRaw) {
+            runCatching { TidalSubscriptionStatus.valueOf(subscriptionRaw) }
+                .getOrDefault(TidalSubscriptionStatus.UNKNOWN)
+        }
+    val accountConfigured = accessToken.isNotBlank()
+
+    fun toast(message: String) {
+        Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+    }
+
+    if (showAddDialog) {
+        TextFieldDialog(
+            icon = { Icon(painterResource(R.drawable.add), null) },
+            title = { Text(stringResource(R.string.tidal_add_instance)) },
+            placeholder = { Text(stringResource(R.string.tidal_instance_url_hint)) },
+            isInputValid = { TidalAudioProvider.normalizeInstanceUrl(it) != null },
+            onDone = { raw ->
+                val normalized = TidalAudioProvider.normalizeInstanceUrl(raw)
+                when {
+                    normalized == null -> toast(context.getString(R.string.tidal_instance_invalid_url))
+                    effectiveInstances.contains(normalized) ->
+                        toast(context.getString(R.string.tidal_instance_duplicate))
+                    else -> persistInstances(effectiveInstances + normalized)
+                }
+            },
+            onDismiss = { showAddDialog = false },
+        )
+    }
 
     Scaffold(
         topBar = {
@@ -125,6 +205,125 @@ fun TidalSettings(navController: NavController) {
                 }
             }
 
+            PreferenceGroup(title = stringResource(R.string.tidal_instances)) {
+                item {
+                    InfoLabel(text = stringResource(R.string.tidal_instances_description))
+                }
+
+                effectiveInstances.forEach { instance ->
+                    item {
+                        PreferenceEntry(
+                            title = { Text(instance) },
+                            description =
+                                healthStatus[instance]
+                                    ?: stringResource(R.string.tidal_instance_unknown),
+                            icon = { Icon(painterResource(R.drawable.link), null) },
+                            trailingContent = {
+                                IconButton(
+                                    onClick = {
+                                        val remaining = effectiveInstances - instance
+                                        healthStatus.remove(instance)
+                                        persistInstances(remaining)
+                                    },
+                                    onLongClick = {},
+                                ) {
+                                    Icon(painterResource(R.drawable.delete), null)
+                                }
+                            },
+                        )
+                    }
+                }
+
+                item {
+                    PreferenceEntry(
+                        title = { Text(stringResource(R.string.tidal_add_instance)) },
+                        icon = { Icon(painterResource(R.drawable.add), null) },
+                        onClick = { showAddDialog = true },
+                    )
+                }
+
+                item {
+                    PreferenceEntry(
+                        title = {
+                            Text(
+                                if (checkingInstances) {
+                                    stringResource(R.string.tidal_checking_instances)
+                                } else {
+                                    stringResource(R.string.tidal_check_instances)
+                                },
+                            )
+                        },
+                        icon = { Icon(painterResource(R.drawable.sync), null) },
+                        isEnabled = !checkingInstances,
+                        onClick = {
+                            checkingInstances = true
+                            coroutineScope.launch {
+                                effectiveInstances.forEach { instance ->
+                                    val latency =
+                                        withContext(Dispatchers.IO) {
+                                            TidalAudioProvider.checkInstance(instance)
+                                        }
+                                    healthStatus[instance] =
+                                        if (latency != null) {
+                                            context.getString(R.string.tidal_instance_healthy, latency.toInt())
+                                        } else {
+                                            context.getString(R.string.tidal_instance_unreachable)
+                                        }
+                                }
+                                checkingInstances = false
+                            }
+                        },
+                    )
+                }
+
+                item {
+                    PreferenceEntry(
+                        title = {
+                            Text(
+                                if (discovering) {
+                                    stringResource(R.string.tidal_discovering)
+                                } else {
+                                    stringResource(R.string.tidal_discover)
+                                },
+                            )
+                        },
+                        description = stringResource(R.string.tidal_discover_description),
+                        icon = { Icon(painterResource(R.drawable.search), null) },
+                        isEnabled = !discovering,
+                        onClick = {
+                            discovering = true
+                            coroutineScope.launch {
+                                val discovered =
+                                    withContext(Dispatchers.IO) {
+                                        TidalAudioProvider.discoverInstances()
+                                    }
+                                val newOnes = discovered.filter { it !in effectiveInstances }
+                                if (newOnes.isNotEmpty()) {
+                                    persistInstances(effectiveInstances + newOnes)
+                                    toast(context.getString(R.string.tidal_discover_result, newOnes.size))
+                                } else if (discovered.isEmpty()) {
+                                    toast(context.getString(R.string.tidal_discover_failed))
+                                } else {
+                                    toast(context.getString(R.string.tidal_discover_none))
+                                }
+                                discovering = false
+                            }
+                        },
+                    )
+                }
+
+                item {
+                    PreferenceEntry(
+                        title = { Text(stringResource(R.string.tidal_reset_instances)) },
+                        icon = { Icon(painterResource(R.drawable.close), null) },
+                        onClick = {
+                            healthStatus.clear()
+                            onStoredInstancesChange("")
+                        },
+                    )
+                }
+            }
+
             PreferenceGroup(title = stringResource(R.string.tidal_artwork)) {
                 item {
                     SwitchPreference(
@@ -149,35 +348,137 @@ fun TidalSettings(navController: NavController) {
 
             PreferenceGroup(title = stringResource(R.string.tidal_account)) {
                 item {
-                    InfoLabel(text = stringResource(R.string.tidal_account_description))
+                    InfoLabel(text = stringResource(R.string.tidal_login_description))
                 }
 
-                item {
-                    EditTextPreference(
-                        title = {
-                            Text(
-                                if (accountConfigured) {
-                                    stringResource(R.string.tidal_account_connected, accountName.ifBlank { "Tidal" })
-                                } else {
-                                    stringResource(R.string.tidal_set_cookie)
+                if (loginInProgress && loginUserCode != null) {
+                    item {
+                        PreferenceEntry(
+                            title = { Text(stringResource(R.string.tidal_login_waiting)) },
+                            description =
+                                stringResource(
+                                    R.string.tidal_login_instructions,
+                                    loginVerificationUri ?: "link.tidal.com",
+                                    loginUserCode ?: "",
+                                ),
+                            icon = { Icon(painterResource(R.drawable.token), null) },
+                            onClick = {
+                                val uri = loginVerificationUri?.let { if (it.startsWith("http")) it else "https://$it" }
+                                if (uri != null) {
+                                    runCatching {
+                                        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(uri)))
+                                    }
+                                }
+                            },
+                        )
+                    }
+                } else if (accountConfigured) {
+                    item {
+                        PreferenceEntry(
+                            title = {
+                                Text(stringResource(R.string.tidal_account_connected, accountName.ifBlank { "Tidal" }))
+                            },
+                            description =
+                                when (subscription) {
+                                    TidalSubscriptionStatus.PREMIUM ->
+                                        stringResource(R.string.tidal_account_premium)
+                                    TidalSubscriptionStatus.FREE ->
+                                        stringResource(R.string.tidal_account_free)
+                                    TidalSubscriptionStatus.UNKNOWN ->
+                                        stringResource(R.string.tidal_account_checking)
                                 },
-                            )
-                        },
-                        icon = { Icon(painterResource(R.drawable.token), null) },
-                        value = tidalCookie,
-                        isInputValid = { normalizeTidalCookieInput(it) != null },
-                        onValueChange = { raw ->
-                            onTidalCookieChange(normalizeTidalCookieInput(raw) ?: "")
-                        },
-                    )
-                }
+                            icon = {
+                                Icon(
+                                    painterResource(
+                                        if (subscription == TidalSubscriptionStatus.FREE) {
+                                            R.drawable.error
+                                        } else {
+                                            R.drawable.token
+                                        },
+                                    ),
+                                    null,
+                                )
+                            },
+                        )
+                    }
 
-                if (accountConfigured) {
+                    if (subscription == TidalSubscriptionStatus.FREE) {
+                        item {
+                            InfoLabel(text = stringResource(R.string.tidal_account_free_warning))
+                        }
+                    }
+
                     item {
                         PreferenceEntry(
                             title = { Text(stringResource(R.string.tidal_disconnect)) },
                             icon = { Icon(painterResource(R.drawable.logout), null) },
-                            onClick = { onTidalCookieChange("") },
+                            onClick = {
+                                coroutineScope.launch {
+                                    context.dataStore.edit { prefs ->
+                                        prefs.remove(TidalAccessTokenKey)
+                                        prefs.remove(TidalRefreshTokenKey)
+                                        prefs.remove(TidalTokenExpiryKey)
+                                        prefs.remove(TidalAccountNameKey)
+                                        prefs[TidalSubscriptionKey] = TidalSubscriptionStatus.UNKNOWN.name
+                                    }
+                                }
+                            },
+                        )
+                    }
+                } else {
+                    item {
+                        PreferenceEntry(
+                            title = { Text(stringResource(R.string.tidal_login)) },
+                            icon = { Icon(painterResource(R.drawable.token), null) },
+                            onClick = {
+                                loginInProgress = true
+                                coroutineScope.launch {
+                                    val token =
+                                        TidalAccountManager.login { auth ->
+                                            withContext(Dispatchers.Main) {
+                                                loginUserCode = auth.userCode
+                                                loginVerificationUri = auth.verificationUriComplete
+                                            }
+                                        }
+                                    if (token != null) {
+                                        val sub =
+                                            token.userId?.let { uid ->
+                                                TidalAccountManager.fetchSubscription(token.accessToken, uid)
+                                            } ?: TidalAccountManager.Subscription.UNKNOWN
+                                        val status =
+                                            when (sub) {
+                                                TidalAccountManager.Subscription.PREMIUM ->
+                                                    TidalSubscriptionStatus.PREMIUM
+                                                TidalAccountManager.Subscription.FREE ->
+                                                    TidalSubscriptionStatus.FREE
+                                                TidalAccountManager.Subscription.UNKNOWN ->
+                                                    TidalSubscriptionStatus.UNKNOWN
+                                            }
+                                        context.dataStore.edit { prefs ->
+                                            prefs[TidalAccessTokenKey] = token.accessToken
+                                            token.refreshToken?.let { prefs[TidalRefreshTokenKey] = it }
+                                            prefs[TidalTokenExpiryKey] = token.expiresAtMillis
+                                            prefs[TidalAccountNameKey] = token.username ?: "Tidal"
+                                            prefs[TidalSubscriptionKey] = status.name
+                                        }
+                                        withContext(Dispatchers.Main) {
+                                            toast(context.getString(R.string.tidal_login_success))
+                                            if (status == TidalSubscriptionStatus.FREE) {
+                                                toast(context.getString(R.string.tidal_account_free_warning))
+                                            }
+                                        }
+                                    } else {
+                                        withContext(Dispatchers.Main) {
+                                            toast(context.getString(R.string.tidal_login_failed))
+                                        }
+                                    }
+                                    withContext(Dispatchers.Main) {
+                                        loginInProgress = false
+                                        loginUserCode = null
+                                        loginVerificationUri = null
+                                    }
+                                }
+                            },
                         )
                     }
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -658,6 +658,44 @@
     <string name="tidal_set_cookie">Set Tidal cookie</string>
     <string name="tidal_account_connected">Connected: %1$s</string>
     <string name="tidal_disconnect">Disconnect Tidal account</string>
+    <!-- Tidal playback notices -->
+    <string name="tidal_playback_fell_back">Tidal couldn\'t resolve this track — playing from YouTube</string>
+    <!-- Tidal HiFi instances -->
+    <string name="tidal_instances">HiFi instances</string>
+    <string name="tidal_instances_description">Tidal streams are resolved through public HiFi/QQDL instances. Add, remove or reorder them; the app tries each in order until one responds.</string>
+    <string name="tidal_add_instance">Add instance</string>
+    <string name="tidal_instance_url_hint">https://instance.example.com</string>
+    <string name="tidal_instance_invalid_url">Enter a valid http(s) URL</string>
+    <string name="tidal_instance_duplicate">That instance is already in the list</string>
+    <string name="tidal_remove_instance">Remove instance</string>
+    <string name="tidal_reset_instances">Reset to default instances</string>
+    <string name="tidal_no_instances">No instances configured. Add one or reset to defaults.</string>
+    <string name="tidal_check_instances">Check instance health</string>
+    <string name="tidal_checking_instances">Checking instances…</string>
+    <string name="tidal_instance_healthy">Online (%1$d ms)</string>
+    <string name="tidal_instance_unreachable">Unreachable</string>
+    <string name="tidal_instance_unknown">Not checked</string>
+    <!-- Tidal instance auto-discovery -->
+    <string name="tidal_discover">Auto-discover instances</string>
+    <string name="tidal_discover_description">Fetch additional public instances from a community list and merge them with your own.</string>
+    <string name="tidal_discovering">Discovering instances…</string>
+    <string name="tidal_discover_result">Added %1$d new instance(s)</string>
+    <string name="tidal_discover_none">No new instances found</string>
+    <string name="tidal_discover_failed">Discovery failed — check your connection or add instances manually</string>
+    <!-- Tidal account login / premium -->
+    <string name="tidal_login">Sign in to Tidal</string>
+    <string name="tidal_login_description">Sign in with your Tidal account to verify your subscription. Playback still uses the public instances above.</string>
+    <string name="tidal_login_start">Start sign-in</string>
+    <string name="tidal_login_instructions">Open %1$s and enter code %2$s, then return here.</string>
+    <string name="tidal_login_open">Open activation page</string>
+    <string name="tidal_login_waiting">Waiting for authorization…</string>
+    <string name="tidal_login_cancel">Cancel sign-in</string>
+    <string name="tidal_login_success">Signed in to Tidal</string>
+    <string name="tidal_login_failed">Tidal sign-in failed or timed out</string>
+    <string name="tidal_account_checking">Checking subscription…</string>
+    <string name="tidal_account_premium">HiFi / Premium subscription active</string>
+    <string name="tidal_account_free">Free account — lossless playback may not work</string>
+    <string name="tidal_account_free_warning">This Tidal account is not HiFi/Premium. Lossless playback through Tidal may fail; the app will fall back to YouTube.</string>
     <string name="discord_integration">Discord Integration</string>
     <string name="account_integrations_summary">Discord, Last.fm, Libre.fm, ListenBrainz</string>
     <string name="discord_login_description">Connect your Discord account with OAuth so ArchiveTune can publish Rich Presence.</string>


### PR DESCRIPTION
## Summary

Follow-up to the initial Tidal integration. Fixes a real playback/caching conflict and makes the Tidal source actually usable, per request: manual HiFi instance management **and** account login + premium detection, with fall-back-to-YouTube notices.

## 1. Playback cache conflict (bug fix)

The ported provider reused YouTube's cache namespace, keyed by the bare `mediaId`:
- The YouTube player-cache short-circuit ran **before** Tidal resolution, so enabling Tidal on an already-cached song did nothing.
- Tidal FLAC bytes were written under the same key as the YouTube stream → cross-source corruption / seek errors when toggling Tidal.
- YouTube loudness normalization was mis-applied to the Tidal stream.

Now:
- Tidal streams use a dedicated cache key (`tidal:<mediaId>`) via `DataSpec.setKey`.
- The **player** cache short-circuit is skipped when Tidal is enabled for a track (persistent **downloads** still win, so offline playback is unaffected).
- Normalization is neutralized for Tidal streams.

## 2. HiFi instance management

The public HiFi/QQDL instances are the actual stream source (they use their own backend Tidal accounts — your account/premium status does not affect this path). Added:
- User-editable instance list (add / remove / reset to defaults).
- Health-check ping (latency per instance).
- Best-effort **auto-discovery** from community sources, merged with the manual list. There is no reliable public registry, so the manual list remains the source of truth and discovery is allowed to fail silently.

## 3. Account login + premium detection

- Optional **Tidal OAuth device-code login** (`TidalAccountManager`): shows a code + activation link, polls for the token.
- After login, resolves the subscription tier and shows **HiFi/Premium** vs **Free**, with a warning that Free accounts may fall back to YouTube.
- Login is optional — playback still works via the public instances without it.

## 4. Fallback notice

When Tidal is enabled but no instance resolves a track, playback falls back to YouTube and shows a one-off toast so the user knows why.

## Files
- `playback/MusicService.kt` — cache namespacing, short-circuit gating, fallback notice, instance wiring
- `tidal/TidalAudioProvider.kt` — configurable instances, health check, discovery
- `tidal/TidalAccountManager.kt` (new) — device-flow login + subscription lookup
- `constants/PreferenceKeys.kt` — instance list, token, subscription keys
- `ui/screens/settings/TidalSettings.kt` — rebuilt with Instances + Account sections
- `res/values/strings.xml` — new strings

## Caveats
- **Not compile-verified** (no Android build environment here) — please run `./gradlew assembleDebug`.
- The device-flow client id/secret are the well-known public Tidal TV client used by open-source tooling; premium detection depends on Tidal's API remaining stable.
