### PR TITLE
[CI only] verify the new ktlint gate runs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,15 @@
 root = true
 
 [*.{kt,kts}]
+# This fork gates ONE ktlint rule and deliberately no more.
+#
+# The whole standard ruleset is switched off first, because ktlint enables it by
+# default and rules like import-ordering / trailing-comma would reformat hundreds of
+# files inherited from upstream. That diff would then collide with the hourly
+# upstream-sync merge on code we do not own, so the cost is paid forever.
+#
+# no-unused-imports is the exception: it catches a real defect (a stale import left
+# behind by an edit), the fix is always a single-line deletion, and it never disagrees
+# with upstream formatting.
+ktlint_standard = disabled
 ktlint_standard_no-unused-imports = enabled

--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -51,6 +51,24 @@ jobs:
               -dname "CN=Android Debug,O=Android,C=US"
           fi
 
+      # Cheapest gate first: ktlint parses sources without compiling them, so a stale
+      # import fails here in seconds rather than after a full assemble.
+      #
+      # The task-list assertion is deliberate. ktlint-gradle only registers its source-set
+      # tasks if it detects a Kotlin plugin on the project, and :app gets Kotlin via AGP
+      # rather than an explicit kotlin-android alias. If that detection ever stops working,
+      # `ktlintCheck` would succeed while checking zero files -- a gate that silently passes
+      # everything. Failing when the per-source-set tasks are absent keeps that honest.
+      - name: Lint (ktlint)
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! ./gradlew --console=plain :app:tasks --all -q | grep -qE '^ktlint\w+SourceSetCheck'; then
+            echo "::error::ktlint registered no source-set check tasks for :app -- the lint gate is not actually running."
+            exit 1
+          fi
+          ./gradlew --console=plain :app:ktlintCheck --warning-mode summary
+
       # Runs before the APK build: unit tests compile a fraction of the project, so a broken
       # assertion surfaces in well under a minute instead of after a full assemble+lint.
       - name: Unit Tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,10 +89,15 @@ checks worth far more than usual:
   adding code, list the external symbols you used and confirm each is imported.
   Same-package types need no import; extensions like `isActive`, `flow.update`,
   and `dataStore.get` do.
-- **Keep imports sorted, with no unused entries.** ktlint fails the build on
-  either. Ordering is the IntelliJ layout: everything alphabetically, with
-  `java.*`, `javax.*`, and `kotlin.*` last. Inserting an import in a plausible
-  but wrong slot is the single most common way to fail a build here.
+- **Remove unused imports.** ktlint's `no-unused-imports` is the one rule this fork
+  gates, and CI fails on it (`Lint (ktlint)` in `build_pull_request.yml`).
+- **Import ordering is NOT enforced — match the surrounding file.** The rest of the
+  standard ruleset is switched off in `.editorconfig`, deliberately: enabling ordering
+  would reformat hundreds of upstream-owned files and collide with the hourly
+  upstream-sync merge forever. The convention here is the IntelliJ layout,
+  everything alphabetical with `java.*`, `javax.*` and `kotlin.*` last, which means
+  `kotlinx.*` sorts BEFORE `kotlin.*` (verified across the tree). Follow the file you
+  are editing; do not "fix" an order that looks wrong but is consistent.
 - **Do not push while a build is in flight.** `build_pull_request.yml` sets
   `cancel-in-progress`, so pushing again cancels the run you were waiting on and
   you never get a verdict. Batch fixes, then push once.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,6 +27,25 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.aboutlibraries.android)
+    alias(libs.plugins.ktlint)
+}
+
+// Lint gate. Only ktlint's no-unused-imports rule is active; .editorconfig explains why the
+// rest of the standard ruleset stays off in this fork.
+//
+// Applied here rather than through `subprojects {}` in the root build, because cross-project
+// configuration is deprecated under Gradle's project-isolation work. ktlint itself resolves from
+// the repositories in settings.gradle.kts -- that uses FAIL_ON_PROJECT_REPOS, so adding a
+// `repositories {}` block here (as the plugin README suggests) would fail the build instead.
+ktlint {
+    // Rule enablement is read from .editorconfig, so it is not duplicated here.
+    android.set(true)
+    ignoreFailures.set(false)
+    // Generated sources (Room, Hilt, KSP) are not ours to format. Uses a predicate because
+    // Gradle's include/exclude only filters files located under the project directory.
+    filter {
+        exclude { it.file.path.contains("${File.separator}build${File.separator}") }
+    }
 }
 
 val localProperties = Properties()

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ai/AiTextService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ai/AiTextService.kt
@@ -16,7 +16,6 @@ import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
-import moe.rukamori.archivetune.BuildConfig
 import moe.rukamori.archivetune.constants.AiProvider
 import org.json.JSONArray
 import org.json.JSONObject

--- a/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/LyricsHelper.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/LyricsHelper.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.withContext
 import moe.rukamori.archivetune.constants.LyricsProviderOrderKey

--- a/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/LyricsHelper.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/LyricsHelper.kt
@@ -12,7 +12,6 @@ import android.util.Log
 import android.util.LruCache
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first

--- a/app/src/main/kotlin/moe/rukamori/archivetune/musicrecognition/MusicRecognitionNotificationManager.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/musicrecognition/MusicRecognitionNotificationManager.kt
@@ -13,7 +13,6 @@ import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
 import androidx.annotation.StringRes
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/Dialog.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/Dialog.kt
@@ -56,7 +56,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.blur
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/Dialog.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/Dialog.kt
@@ -59,7 +59,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/SettingsDialogBlur.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/SettingsDialogBlur.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.staticCompositionLocalOf
 
 /**
  * Tracks whether any settings dialog is currently showing, so the parent

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -22,7 +22,6 @@ import android.provider.Settings
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.spring

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/musicrecognition/MusicRecognitionDetailsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/musicrecognition/MusicRecognitionDetailsScreen.kt
@@ -31,8 +31,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.ui.text.font.FontWeight
 import androidx.navigation.NavHostController
 import androidx.window.core.layout.WindowSizeClass
 import androidx.window.core.layout.WindowWidthSizeClass

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlaybackSourceSections.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlaybackSourceSections.kt
@@ -69,7 +69,6 @@ import moe.rukamori.archivetune.constants.PoTokenPlayerKey
 import moe.rukamori.archivetune.innertube.utils.hasYouTubeLoginCookie
 import moe.rukamori.archivetune.ui.component.DefaultDialog
 import moe.rukamori.archivetune.ui.component.EnumListPreference
-import moe.rukamori.archivetune.ui.component.InfoLabel
 import moe.rukamori.archivetune.ui.component.ListPreference
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
 import moe.rukamori.archivetune.ui.component.PreferenceGroup

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlayerSettings.kt
@@ -19,7 +19,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlayerSettings.kt
@@ -67,7 +67,6 @@ import moe.rukamori.archivetune.ui.component.SwitchPreference
 import moe.rukamori.archivetune.ui.component.TagsManagementDialog
 import moe.rukamori.archivetune.ui.component.TextFieldDialog
 import moe.rukamori.archivetune.ui.utils.backToMain
-import moe.rukamori.archivetune.utils.rememberEnumPreference
 import moe.rukamori.archivetune.utils.rememberPreference
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/QobuzSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/QobuzSettings.kt
@@ -36,12 +36,9 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialogDefaults
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Surface

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/TidalSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/TidalSettings.kt
@@ -33,7 +33,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.widthIn

--- a/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/LyricsMenuViewModel.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/LyricsMenuViewModel.kt
@@ -10,7 +10,6 @@ package moe.rukamori.archivetune.viewmodels
 import android.content.Context
 import androidx.annotation.StringRes
 import androidx.compose.runtime.Immutable
-import androidx.datastore.preferences.core.edit
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.common.collect.ImmutableList

--- a/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/LyricsMenuViewModel.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/LyricsMenuViewModel.kt
@@ -31,8 +31,6 @@ import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.ai.AiLyricsTranslator
 import moe.rukamori.archivetune.ai.AiServiceConfig
 import moe.rukamori.archivetune.constants.AiApiKeyKey
-import moe.rukamori.archivetune.constants.AiApiValidationStatus
-import moe.rukamori.archivetune.constants.AiApiValidationStatusKey
 import moe.rukamori.archivetune.constants.AiCustomEndpointKey
 import moe.rukamori.archivetune.constants.AiCustomModelKey
 import moe.rukamori.archivetune.constants.AiProvider

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.aboutlibraries.android) apply false
+    alias(libs.plugins.ktlint) apply false
 }
 
 tasks.register<Delete>("clean") {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,6 +47,7 @@ accompanist = "1.0.19"
 accompanist-core = "0.4.7"
 androidsvg = "1.4"
 aboutLibraries = "15.0.3"
+ktlintPlugin = "14.2.0"
 
 
 [libraries]
@@ -170,3 +171,4 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 aboutlibraries-android = { id = "com.mikepenz.aboutlibraries.plugin.android", version.ref = "aboutLibraries" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlintPlugin" }


### PR DESCRIPTION
Opened solely to exercise the new `Lint (ktlint)` step in build_pull_request.yml, which does not run on push events. Not for merge.