### PR TITLE
Rewrite the Apple Music player: dead queue button, jank and ignored settings

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -252,9 +252,13 @@ fun AppleMusicPlayerContent(
                 modifier =
                     Modifier
                         .matchParentSize()
-                        // backdropBlurAmount is a 0..100 scale; map it onto the same 25dp ceiling
-                        // BackdropBlurApi30 uses so both paths look alike at a given setting.
-                        .blur((backdropBlurAmount * 25 / 100f).coerceIn(1f, 25f).dp),
+                        // 0..100 mapped onto a 60dp ceiling, matching the full-screen thumbnail
+                        // backdrop in Thumbnail.kt. Deliberately NOT the 25 that BackdropBlurApi30
+                        // uses: that radius is applied to a downscaled 500px bitmap, so 25 there is
+                        // a much stronger blur than 25dp across a full-screen image. Reusing 25 here
+                        // would leave API 31+ looking nearly unblurred next to older devices, and
+                        // well short of the 72dp this design originally hardcoded.
+                        .blur((backdropBlurAmount * 60 / 100f).coerceIn(1f, 60f).dp),
             )
         } else {
             BackdropBlurApi30(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
-import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -47,19 +46,13 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithContent
-import androidx.compose.ui.geometry.CornerRadius
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
@@ -106,6 +99,7 @@ private val AppleMusicChipSize = 34.dp
 private val AppleMusicTransportIconSize = 52.dp
 private val AppleMusicPlayPauseIconSize = 62.dp
 private val AppleMusicBottomIconSize = 24.dp
+private val AppleMusicSeekIdleTrackHeight = 7.dp
 
 /** Distance a drag must travel before it counts as a deliberate swipe rather than a stray move. */
 private val AppleMusicSwipeThreshold = 72.dp
@@ -788,7 +782,15 @@ private fun AppleMusicBottomButton(
     }
 }
 
-/** Thin Apple-Music-style scrubber: rounded track, no thumb, tap + drag to seek. */
+/**
+ * Thin Apple-Music-style scrubber.
+ *
+ * Delegates to the shared [AppleMusicFlatSlider] rather than redrawing the same track a second
+ * time. This used to be its own copy of the identical gesture-and-draw code, which meant the seek
+ * bar missed the animation work that landed on the volume slider: the fill jumped between
+ * positions instead of gliding, and the track did not thicken under the finger. Sharing the
+ * component also keeps the scrubber and the volume row from drifting apart visually.
+ */
 @Composable
 private fun AppleMusicSeekBar(
     position: Long,
@@ -796,60 +798,14 @@ private fun AppleMusicSeekBar(
     onScrub: (Long) -> Unit,
     onScrubFinished: () -> Unit,
 ) {
-    val enabled = duration > 0L
-    var dragging by remember { mutableStateOf(false) }
-    var dragFraction by remember { mutableFloatStateOf(0f) }
-    val playedFraction =
-        if (duration > 0L) (position.toFloat() / duration).coerceIn(0f, 1f) else 0f
-    val shownFraction = if (dragging) dragFraction else playedFraction
-
-    Box(
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .height(26.dp)
-                .pointerInput(enabled, duration) {
-                    if (!enabled) return@pointerInput
-                    detectTapGestures { offset ->
-                        val fraction = (offset.x / size.width).coerceIn(0f, 1f)
-                        onScrub((fraction * duration).toLong())
-                        onScrubFinished()
-                    }
-                }.pointerInput(enabled, duration) {
-                    if (!enabled) return@pointerInput
-                    detectHorizontalDragGestures(
-                        onDragStart = { offset ->
-                            dragging = true
-                            dragFraction = (offset.x / size.width).coerceIn(0f, 1f)
-                            onScrub((dragFraction * duration).toLong())
-                        },
-                        onDragEnd = {
-                            dragging = false
-                            onScrubFinished()
-                        },
-                        onDragCancel = { dragging = false },
-                        onHorizontalDrag = { change, _ ->
-                            change.consume()
-                            dragFraction = (change.position.x / size.width).coerceIn(0f, 1f)
-                            onScrub((dragFraction * duration).toLong())
-                        },
-                    )
-                }.drawWithContent {
-                    val trackHeight = if (dragging) 10.dp.toPx() else 7.dp.toPx()
-                    val top = (size.height - trackHeight) / 2f
-                    val radius = CornerRadius(trackHeight / 2f)
-                    drawRoundRect(
-                        color = Color.White.copy(alpha = 0.28f),
-                        topLeft = Offset(0f, top),
-                        size = Size(size.width, trackHeight),
-                        cornerRadius = radius,
-                    )
-                    drawRoundRect(
-                        color = Color.White.copy(alpha = if (dragging) 1f else 0.85f),
-                        topLeft = Offset(0f, top),
-                        size = Size(size.width * shownFraction, trackHeight),
-                        cornerRadius = radius,
-                    )
-                },
+    AppleMusicFlatSlider(
+        fraction = if (duration > 0L) (position.toFloat() / duration).coerceIn(0f, 1f) else 0f,
+        onFractionChange = { fraction -> onScrub((fraction * duration).toLong()) },
+        onFractionChangeFinished = onScrubFinished,
+        enabled = duration > 0L,
+        // The scrubber reads a touch heavier than the volume track in this design, so keep its
+        // slightly taller idle height rather than inheriting the shared default.
+        idleTrackHeight = AppleMusicSeekIdleTrackHeight,
+        modifier = Modifier.fillMaxWidth(),
     )
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -19,7 +19,6 @@ package moe.rukamori.archivetune.ui.player
 
 import android.content.Intent
 import android.os.Build
-import android.os.Build
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -19,6 +19,7 @@ package moe.rukamori.archivetune.ui.player
 
 import android.content.Intent
 import android.os.Build
+import android.os.Build
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
@@ -161,9 +162,9 @@ fun AppleMusicPlayerContent(
     //   ThumbnailCornerRadiusKey  — the sharp square artwork is the defining trait.
     val (disableBlur) = rememberPreference(DisableBlurKey, defaultValue = false)
     // Backdrop strength uses BackdropEnabled/BackdropBlurAmount, the same pair Thumbnail.kt and
-    // Player.kt read. NOT BlurRadiusKey: despite its name nothing consumes that key outside the
-    // settings slider that writes it, so honouring it here would react to a control that has no
-    // effect anywhere else in the app.
+    // Player.kt read for player backdrops. Not BlurRadiusKey, which despite the similar name is a
+    // separate setting scoped to the lyrics sheet background (Player.kt hands it to LyricsScreen and
+    // nowhere else). This full-screen artwork is a player backdrop, so it belongs to the former pair.
     val (backdropEnabled) = rememberPreference(BackdropEnabledKey, defaultValue = true)
     val (backdropBlurAmount) = rememberPreference(BackdropBlurAmountKey, defaultValue = 60)
     val (showPlayerVolumeBar) = rememberPreference(ShowPlayerVolumeBarKey, defaultValue = true)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -9,12 +9,15 @@
  * "more" chips, a thin scrubber with elapsed/-remaining times, bare oversized transport glyphs, a
  * flat volume slider, and a bottom lyrics / output / queue icon row. Everything is tinted by the
  * artwork itself (no palette extraction needed — the blur provides the color).
+ *
+ * Gesture ownership matters here. Swipe gestures live on the artwork ONLY, never on the controls
+ * column: a drag detector wrapping the controls consumes events before the buttons and sliders
+ * beneath it can see a tap, which is what previously left the queue button dead.
  */
 
 package moe.rukamori.archivetune.ui.player
 
 import android.content.Intent
-import android.os.Build
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
@@ -35,13 +38,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.ripple
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -49,7 +51,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.CornerRadius
@@ -73,6 +74,12 @@ import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.navigation.NavController
 import coil3.compose.AsyncImage
 import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.constants.BlurRadiusKey
+import moe.rukamori.archivetune.constants.DisableBlurKey
+import moe.rukamori.archivetune.constants.PlayerButtonsStyle
+import moe.rukamori.archivetune.constants.PlayerButtonsStyleKey
+import moe.rukamori.archivetune.constants.ShowPlayerVolumeBarKey
+import moe.rukamori.archivetune.constants.SwipeThumbnailKey
 import moe.rukamori.archivetune.extensions.togglePlayPause
 import moe.rukamori.archivetune.models.MediaMetadata
 import moe.rukamori.archivetune.playback.PlayerConnection
@@ -84,13 +91,18 @@ import moe.rukamori.archivetune.ui.menu.rememberCastPlayerMenuAction
 import moe.rukamori.archivetune.ui.utils.ShowMediaInfo
 import moe.rukamori.archivetune.ui.utils.highRes
 import moe.rukamori.archivetune.utils.makeTimeString
+import moe.rukamori.archivetune.utils.rememberEnumPreference
 import moe.rukamori.archivetune.utils.rememberLowDataModeActive
+import moe.rukamori.archivetune.utils.rememberPreference
 
 private val AppleMusicContentPadding = 28.dp
 private val AppleMusicChipSize = 34.dp
 private val AppleMusicTransportIconSize = 52.dp
 private val AppleMusicPlayPauseIconSize = 62.dp
 private val AppleMusicBottomIconSize = 24.dp
+
+/** Distance a drag must travel before it counts as a deliberate swipe rather than a stray move. */
+private val AppleMusicSwipeThreshold = 72.dp
 
 @Composable
 fun AppleMusicPlayerContent(
@@ -134,6 +146,39 @@ fun AppleMusicPlayerContent(
     val menuState = LocalMenuState.current
     val context = LocalContext.current
 
+    // Preferences this design honours. Read here rather than threaded down from BottomSheetPlayer so
+    // the design stays self-contained, matching how Thumbnail.kt and MiniPlayer.kt read the same
+    // keys. DataStore is still the single source of truth, so the values cannot diverge.
+    //
+    // Deliberately NOT honoured, because each would erase what makes this design recognisable — and
+    // the design is itself an explicit user choice via PlayerDesignStyleKey:
+    //   SliderStyleKey            — Wavy/Circular would replace the signature flat scrubber.
+    //   PlayerBackgroundStyleKey  — the artwork-tinted panel *is* the Apple Music background.
+    //                               (BottomSheetPlayer already forces DEFAULT for this design.)
+    //   ThumbnailCornerRadiusKey  — the sharp square artwork is the defining trait.
+    val (disableBlur) = rememberPreference(DisableBlurKey, defaultValue = false)
+    val (blurRadius) = rememberPreference(BlurRadiusKey, defaultValue = 48f)
+    val (showPlayerVolumeBar) = rememberPreference(ShowPlayerVolumeBarKey, defaultValue = true)
+    val (swipeThumbnail) = rememberPreference(SwipeThumbnailKey, defaultValue = true)
+    val playerButtonsStyle by rememberEnumPreference(
+        key = PlayerButtonsStyleKey,
+        defaultValue = PlayerButtonsStyle.DEFAULT,
+    )
+
+    // The chips carry their own background, so an accent stays legible there. The oversized
+    // transport glyphs sit directly on artwork and stay white for contrast — the same compromise
+    // Player.kt makes for the V7/V8 designs.
+    val chipBackground =
+        when (playerButtonsStyle) {
+            PlayerButtonsStyle.DEFAULT -> Color.White.copy(alpha = 0.14f)
+            PlayerButtonsStyle.SECONDARY -> MaterialTheme.colorScheme.secondary
+        }
+    val chipTint =
+        when (playerButtonsStyle) {
+            PlayerButtonsStyle.DEFAULT -> Color.White
+            PlayerButtonsStyle.SECONDARY -> MaterialTheme.colorScheme.onSecondary
+        }
+
     val onPlayPauseClick = {
         if (playbackState == STATE_ENDED) {
             playerConnection.player.seekTo(0, 0)
@@ -173,38 +218,36 @@ fun AppleMusicPlayerContent(
     BoxWithConstraints(modifier = modifier) {
         val sharpArtworkHeight = if (landscape) maxHeight else maxHeight * 0.55f
 
-        // 1. Blurred artwork fills the whole player as the base layer. On Android 12+ this is a
-        // real gaussian blur; below that the scrim alone carries the contrast.
-        AsyncImage(
-            model = artworkRequest ?: artworkUrl,
-            contentDescription = null,
-            contentScale = ContentScale.Crop,
-            modifier =
-                Modifier
-                    .matchParentSize()
-                    .then(
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                            Modifier.blur(72.dp)
-                        } else {
-                            Modifier
-                        },
-                    ).graphicsLayer {
-                        scaleX = 1.2f
-                        scaleY = 1.2f
-                    },
-        )
+        // 1. Blurred artwork fills the whole player as the base layer.
+        if (disableBlur) {
+            // Blur disabled: the scrim below carries all the contrast on its own.
+            AsyncImage(
+                model = artworkRequest ?: artworkUrl,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.matchParentSize(),
+            )
+        } else {
+            BackdropBlurApi30(
+                model = artworkUrl,
+                blurAmount = blurRadius.toInt().coerceIn(1, 100),
+                modifier = Modifier.matchParentSize(),
+            )
+        }
         // Deep contrast scrim over the blur: the Apple Music sheet reads as a dark, artwork-tinted
         // panel rather than a bright blur, so the whole surface is pulled well down in brightness
-        // and pushed darker still toward the bottom where the controls sit.
+        // and pushed darker still toward the bottom where the controls sit. Without a blur the
+        // artwork stays sharp underneath, so the scrim has to work harder to keep text legible.
+        val scrimBoost = if (disableBlur) 0.10f else 0f
         Box(
             modifier =
                 Modifier
                     .matchParentSize()
                     .background(
                         Brush.verticalGradient(
-                            0f to Color.Black.copy(alpha = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) 0.42f else 0.52f),
-                            0.5f to Color.Black.copy(alpha = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) 0.60f else 0.68f),
-                            1f to Color.Black.copy(alpha = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) 0.82f else 0.86f),
+                            0f to Color.Black.copy(alpha = 0.42f + scrimBoost),
+                            0.5f to Color.Black.copy(alpha = 0.60f + scrimBoost),
+                            1f to Color.Black.copy(alpha = 0.82f + scrimBoost),
                         ),
                     ),
         )
@@ -218,6 +261,12 @@ fun AppleMusicPlayerContent(
                     canvasFallbackUrl = canvasFallbackUrl,
                     isPlaying = isPlaying,
                     fadeBottom = false,
+                    swipeThumbnail = swipeThumbnail,
+                    canSkipPrevious = canSkipPrevious,
+                    canSkipNext = canSkipNext,
+                    onSkipPrevious = playerConnection::seekToPrevious,
+                    onSkipNext = playerConnection::seekToNext,
+                    onQueueClick = onQueueClick,
                     modifier =
                         Modifier
                             .weight(1f)
@@ -236,6 +285,9 @@ fun AppleMusicPlayerContent(
                     currentSongLiked = currentSongLiked,
                     volume = volume,
                     onVolumeChange = onVolumeChange,
+                    showVolumeBar = showPlayerVolumeBar,
+                    chipBackground = chipBackground,
+                    chipTint = chipTint,
                     titleActions = titleActions,
                     onPlayPauseClick = onPlayPauseClick,
                     onMoreClick = onMoreClick,
@@ -260,6 +312,12 @@ fun AppleMusicPlayerContent(
                 canvasFallbackUrl = canvasFallbackUrl,
                 isPlaying = isPlaying,
                 fadeBottom = true,
+                swipeThumbnail = swipeThumbnail,
+                canSkipPrevious = canSkipPrevious,
+                canSkipNext = canSkipNext,
+                onSkipPrevious = playerConnection::seekToPrevious,
+                onSkipNext = playerConnection::seekToNext,
+                onQueueClick = onQueueClick,
                 modifier =
                     Modifier
                         .fillMaxWidth()
@@ -267,7 +325,7 @@ fun AppleMusicPlayerContent(
                         .align(Alignment.TopCenter),
             )
 
-            // 3. Controls anchored to the bottom.
+            // 3. Controls anchored to the bottom. No gesture detector wraps this — see file header.
             AppleMusicControlsColumn(
                 mediaMetadata = mediaMetadata,
                 isPlaying = isPlaying,
@@ -281,6 +339,9 @@ fun AppleMusicPlayerContent(
                 currentSongLiked = currentSongLiked,
                 volume = volume,
                 onVolumeChange = onVolumeChange,
+                showVolumeBar = showPlayerVolumeBar,
+                chipBackground = chipBackground,
+                chipTint = chipTint,
                 titleActions = titleActions,
                 onPlayPauseClick = onPlayPauseClick,
                 onMoreClick = onMoreClick,
@@ -308,30 +369,75 @@ private fun AppleMusicSharpArtwork(
     canvasFallbackUrl: String?,
     isPlaying: Boolean,
     fadeBottom: Boolean,
+    swipeThumbnail: Boolean,
+    canSkipPrevious: Boolean,
+    canSkipNext: Boolean,
+    onSkipPrevious: () -> Unit,
+    onSkipNext: () -> Unit,
+    onQueueClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Box(
         modifier =
-            modifier.then(
-                if (fadeBottom) {
-                    // Fade the sharp artwork's lower edge into the blurred layer beneath.
-                    Modifier
-                        .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen }
-                        .drawWithContent {
-                            drawContent()
-                            drawRect(
-                                brush =
-                                    Brush.verticalGradient(
-                                        0.62f to Color.Black,
-                                        1f to Color.Transparent,
-                                    ),
-                                blendMode = androidx.compose.ui.graphics.BlendMode.DstIn,
-                            )
-                        }
-                } else {
-                    Modifier
+            modifier
+                .then(
+                    if (fadeBottom) {
+                        // Fade the sharp artwork's lower edge into the blurred layer beneath.
+                        Modifier
+                            .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen }
+                            .drawWithContent {
+                                drawContent()
+                                drawRect(
+                                    brush =
+                                        Brush.verticalGradient(
+                                            0.62f to Color.Black,
+                                            1f to Color.Transparent,
+                                        ),
+                                    blendMode = androidx.compose.ui.graphics.BlendMode.DstIn,
+                                )
+                            }
+                    } else {
+                        Modifier
+                    },
+                )
+                // Swipe gestures live here, on artwork with no interactive children, so consuming
+                // events cannot steal taps from a button. The two detectors each wait for slop on
+                // their own axis, so whichever axis the finger commits to wins cleanly.
+                .pointerInput(swipeThumbnail, canSkipPrevious, canSkipNext) {
+                    if (!swipeThumbnail) return@pointerInput
+                    val threshold = AppleMusicSwipeThreshold.toPx()
+                    var travelled = 0f
+                    detectHorizontalDragGestures(
+                        onDragStart = { travelled = 0f },
+                        onDragCancel = { travelled = 0f },
+                        onDragEnd = {
+                            when {
+                                travelled <= -threshold && canSkipNext -> onSkipNext()
+                                travelled >= threshold && canSkipPrevious -> onSkipPrevious()
+                            }
+                            travelled = 0f
+                        },
+                        onHorizontalDrag = { change, dragAmount ->
+                            change.consume()
+                            travelled += dragAmount
+                        },
+                    )
+                }.pointerInput(Unit) {
+                    val threshold = AppleMusicSwipeThreshold.toPx()
+                    var travelled = 0f
+                    detectVerticalDragGestures(
+                        onDragStart = { travelled = 0f },
+                        onDragCancel = { travelled = 0f },
+                        onDragEnd = {
+                            if (travelled <= -threshold) onQueueClick()
+                            travelled = 0f
+                        },
+                        onVerticalDrag = { change, dragAmount ->
+                            change.consume()
+                            travelled += dragAmount
+                        },
+                    )
                 },
-            ),
     ) {
         AsyncImage(
             model = artworkRequest ?: artworkUrl,
@@ -365,6 +471,9 @@ private fun AppleMusicControlsColumn(
     currentSongLiked: Boolean,
     volume: Float,
     onVolumeChange: (Float) -> Unit,
+    showVolumeBar: Boolean,
+    chipBackground: Color,
+    chipTint: Color,
     titleActions: PlayerTitleActions,
     onPlayPauseClick: () -> Unit,
     onMoreClick: () -> Unit,
@@ -375,34 +484,8 @@ private fun AppleMusicControlsColumn(
     onSliderValueChangeFinished: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var swipeUpAccumulated by remember { mutableFloatStateOf(0f) }
-    val swipeUpThreshold = 120f
-    val resetSwipeUp = remember {
-        {
-            if (swipeUpAccumulated != 0f) swipeUpAccumulated = 0f
-        }
-    }
-    LaunchedEffect(Unit) { kotlinx.coroutines.delay(300); resetSwipeUp() }
-
     Column(
-        modifier = modifier
-            .padding(horizontal = AppleMusicContentPadding)
-            .pointerInput(Unit) {
-                detectVerticalDragGestures(
-                    onDragEnd = {
-                        if (swipeUpAccumulated < -swipeUpThreshold) {
-                            onQueueClick()
-                        }
-                        swipeUpAccumulated = 0f
-                    },
-                    onVerticalDrag = { change, dragAmount ->
-                        change.consume()
-                        if (dragAmount < 0f) { // upward swipe
-                            swipeUpAccumulated = (swipeUpAccumulated + dragAmount).coerceAtLeast(-swipeUpThreshold * 1.5f)
-                        }
-                    },
-                )
-            },
+        modifier = modifier.padding(horizontal = AppleMusicContentPadding),
         verticalArrangement = Arrangement.SpaceEvenly,
     ) {
         // Title / artist row with star + more chips.
@@ -440,14 +523,16 @@ private fun AppleMusicControlsColumn(
             Spacer(Modifier.width(12.dp))
             AppleMusicChip(
                 iconRes = if (currentSongLiked) R.drawable.player_star_filled else R.drawable.player_star,
-                tint = if (currentSongLiked) Color(0xFFFFD700) else Color.White,
+                background = chipBackground,
+                tint = if (currentSongLiked) Color(0xFFFFD700) else chipTint,
                 contentDescription = null,
                 onClick = playerConnection::toggleLike,
             )
             Spacer(Modifier.width(10.dp))
             AppleMusicChip(
                 iconRes = R.drawable.player_more_horiz,
-                tint = Color.White,
+                background = chipBackground,
+                tint = chipTint,
                 contentDescription = null,
                 onClick = onMoreClick,
             )
@@ -516,29 +601,12 @@ private fun AppleMusicControlsColumn(
             )
         }
 
-        // Flat volume slider with speaker glyphs.
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            Icon(
-                painter = painterResource(R.drawable.player_volume_min),
-                contentDescription = null,
-                tint = Color.White.copy(alpha = 0.55f),
-                modifier = Modifier.size(18.dp),
-            )
-            Spacer(Modifier.width(12.dp))
-            AppleMusicVolumeSlider(
+        // Flat volume slider with speaker glyphs, shared with the lyrics screen.
+        if (showVolumeBar) {
+            AppleMusicVolumeRow(
                 volume = volume,
                 onVolumeChange = onVolumeChange,
-                modifier = Modifier.weight(1f),
-            )
-            Spacer(Modifier.width(12.dp))
-            Icon(
-                painter = painterResource(R.drawable.player_volume_up),
-                contentDescription = null,
-                tint = Color.White.copy(alpha = 0.55f),
-                modifier = Modifier.size(18.dp),
+                modifier = Modifier.fillMaxWidth(),
             )
         }
 
@@ -570,6 +638,7 @@ private fun AppleMusicControlsColumn(
 @Composable
 private fun AppleMusicChip(
     iconRes: Int,
+    background: Color,
     tint: Color,
     contentDescription: String?,
     onClick: () -> Unit,
@@ -580,7 +649,7 @@ private fun AppleMusicChip(
             Modifier
                 .size(AppleMusicChipSize)
                 .clip(CircleShape)
-                .background(Color.White.copy(alpha = 0.14f))
+                .background(background)
                 .clickable(onClick = onClick),
     ) {
         Icon(
@@ -652,7 +721,7 @@ private fun AppleMusicBottomButton(
     }
 }
 
-/** Thin Apple-Music-style scrubber: rounded 6dp track, no thumb, tap + drag to seek. */
+/** Thin Apple-Music-style scrubber: rounded track, no thumb, tap + drag to seek. */
 @Composable
 private fun AppleMusicSeekBar(
     position: Long,
@@ -712,46 +781,6 @@ private fun AppleMusicSeekBar(
                         color = Color.White.copy(alpha = if (dragging) 1f else 0.85f),
                         topLeft = Offset(0f, top),
                         size = Size(size.width * shownFraction, trackHeight),
-                        cornerRadius = radius,
-                    )
-                },
-    )
-}
-
-/** Flat volume slider matching the scrubber's look. */
-@Composable
-private fun AppleMusicVolumeSlider(
-    volume: Float,
-    onVolumeChange: (Float) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Box(
-        modifier =
-            modifier
-                .height(26.dp)
-                .pointerInput(Unit) {
-                    detectTapGestures { offset ->
-                        onVolumeChange((offset.x / size.width).coerceIn(0f, 1f))
-                    }
-                }.pointerInput(Unit) {
-                    detectHorizontalDragGestures { change, _ ->
-                        change.consume()
-                        onVolumeChange((change.position.x / size.width).coerceIn(0f, 1f))
-                    }
-                }.drawWithContent {
-                    val trackHeight = 6.dp.toPx()
-                    val top = (size.height - trackHeight) / 2f
-                    val radius = CornerRadius(trackHeight / 2f)
-                    drawRoundRect(
-                        color = Color.White.copy(alpha = 0.28f),
-                        topLeft = Offset(0f, top),
-                        size = Size(size.width, trackHeight),
-                        cornerRadius = radius,
-                    )
-                    drawRoundRect(
-                        color = Color.White.copy(alpha = 0.85f),
-                        topLeft = Offset(0f, top),
-                        size = Size(size.width * volume.coerceIn(0f, 1f), trackHeight),
                         cornerRadius = radius,
                     )
                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -18,6 +18,7 @@
 package moe.rukamori.archivetune.ui.player
 
 import android.content.Intent
+import android.os.Build
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
@@ -51,6 +52,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.CornerRadius
@@ -74,7 +76,8 @@ import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.navigation.NavController
 import coil3.compose.AsyncImage
 import moe.rukamori.archivetune.R
-import moe.rukamori.archivetune.constants.BlurRadiusKey
+import moe.rukamori.archivetune.constants.BackdropBlurAmountKey
+import moe.rukamori.archivetune.constants.BackdropEnabledKey
 import moe.rukamori.archivetune.constants.DisableBlurKey
 import moe.rukamori.archivetune.constants.PlayerButtonsStyle
 import moe.rukamori.archivetune.constants.PlayerButtonsStyleKey
@@ -157,7 +160,12 @@ fun AppleMusicPlayerContent(
     //                               (BottomSheetPlayer already forces DEFAULT for this design.)
     //   ThumbnailCornerRadiusKey  — the sharp square artwork is the defining trait.
     val (disableBlur) = rememberPreference(DisableBlurKey, defaultValue = false)
-    val (blurRadius) = rememberPreference(BlurRadiusKey, defaultValue = 48f)
+    // Backdrop strength uses BackdropEnabled/BackdropBlurAmount, the same pair Thumbnail.kt and
+    // Player.kt read. NOT BlurRadiusKey: despite its name nothing consumes that key outside the
+    // settings slider that writes it, so honouring it here would react to a control that has no
+    // effect anywhere else in the app.
+    val (backdropEnabled) = rememberPreference(BackdropEnabledKey, defaultValue = true)
+    val (backdropBlurAmount) = rememberPreference(BackdropBlurAmountKey, defaultValue = 60)
     val (showPlayerVolumeBar) = rememberPreference(ShowPlayerVolumeBarKey, defaultValue = true)
     val (swipeThumbnail) = rememberPreference(SwipeThumbnailKey, defaultValue = true)
     val playerButtonsStyle by rememberEnumPreference(
@@ -219,18 +227,39 @@ fun AppleMusicPlayerContent(
         val sharpArtworkHeight = if (landscape) maxHeight else maxHeight * 0.55f
 
         // 1. Blurred artwork fills the whole player as the base layer.
-        if (disableBlur) {
-            // Blur disabled: the scrim below carries all the contrast on its own.
+        //
+        // Mirrors the strategy Player.kt uses for every other design rather than inventing a third
+        // one. On API 31+ Modifier.blur compiles to a hardware RenderEffect, so a live blur is cheap
+        // and stays sharp at any radius. Below 31 there is no RenderEffect, so Compose falls back to
+        // re-running a software gaussian over a full-screen bitmap EVERY frame -- that is what made
+        // the lyrics transition choppy in this design specifically, since it hardcoded a live
+        // blur(72.dp) with no API split at all. BackdropBlurApi30 blurs once into a cached 500px
+        // bitmap off the main thread instead, so the per-frame cost there drops to zero.
+        val hasBlur = !disableBlur && backdropEnabled && backdropBlurAmount > 0
+        if (!hasBlur) {
+            // Blur off: the scrim below carries all the contrast on its own.
             AsyncImage(
                 model = artworkRequest ?: artworkUrl,
                 contentDescription = null,
                 contentScale = ContentScale.Crop,
                 modifier = Modifier.matchParentSize(),
             )
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            AsyncImage(
+                model = artworkRequest ?: artworkUrl,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier =
+                    Modifier
+                        .matchParentSize()
+                        // backdropBlurAmount is a 0..100 scale; map it onto the same 25dp ceiling
+                        // BackdropBlurApi30 uses so both paths look alike at a given setting.
+                        .blur((backdropBlurAmount * 25 / 100f).coerceIn(1f, 25f).dp),
+            )
         } else {
             BackdropBlurApi30(
                 model = artworkUrl,
-                blurAmount = blurRadius.toInt().coerceIn(1, 100),
+                blurAmount = backdropBlurAmount,
                 modifier = Modifier.matchParentSize(),
             )
         }
@@ -238,7 +267,10 @@ fun AppleMusicPlayerContent(
         // panel rather than a bright blur, so the whole surface is pulled well down in brightness
         // and pushed darker still toward the bottom where the controls sit. Without a blur the
         // artwork stays sharp underneath, so the scrim has to work harder to keep text legible.
-        val scrimBoost = if (disableBlur) 0.10f else 0f
+        // Keyed on hasBlur, not disableBlur alone: the backdrop can also be off because the user
+        // turned it off or set its amount to zero, and a sharp artwork needs the heavier scrim in
+        // every one of those cases for the white text to stay legible.
+        val scrimBoost = if (hasBlur) 0f else 0.10f
         Box(
             modifier =
                 Modifier
@@ -704,7 +736,10 @@ private fun AppleMusicBottomButton(
         contentAlignment = Alignment.Center,
         modifier =
             Modifier
-                .size(44.dp)
+                // 48dp, not the icon's 22dp: this is the Material minimum touch target, and the
+                // queue button on this row is the one that was unreachable, so it is worth the few
+                // extra dp of hit area even though the glyph itself stays small.
+                .size(48.dp)
                 .clip(CircleShape)
                 .clickable(
                     interactionSource = remember { MutableInteractionSource() },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -49,6 +49,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -413,6 +414,15 @@ private fun AppleMusicSharpArtwork(
     onQueueClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    // The detectors below are keyed on values that rarely change, so a lambda captured directly gets
+    // pinned to the composition that created it. openQueue upstream is a
+    // remember(state, queueSheetState), so if either sheet state is recreated a captured copy would
+    // keep calling expandSoft() on the orphaned one -- a silently dead swipe. Reading through
+    // rememberUpdatedState keeps the current lambda without making it a pointerInput key, which
+    // would otherwise tear down the gesture mid-drag.
+    val currentOnSkipNext by rememberUpdatedState(onSkipNext)
+    val currentOnSkipPrevious by rememberUpdatedState(onSkipPrevious)
+    val currentOnQueueClick by rememberUpdatedState(onQueueClick)
     Box(
         modifier =
             modifier
@@ -448,8 +458,8 @@ private fun AppleMusicSharpArtwork(
                         onDragCancel = { travelled = 0f },
                         onDragEnd = {
                             when {
-                                travelled <= -threshold && canSkipNext -> onSkipNext()
-                                travelled >= threshold && canSkipPrevious -> onSkipPrevious()
+                                travelled <= -threshold && canSkipNext -> currentOnSkipNext()
+                                travelled >= threshold && canSkipPrevious -> currentOnSkipPrevious()
                             }
                             travelled = 0f
                         },
@@ -465,7 +475,7 @@ private fun AppleMusicSharpArtwork(
                         onDragStart = { travelled = 0f },
                         onDragCancel = { travelled = 0f },
                         onDragEnd = {
-                            if (travelled <= -threshold) onQueueClick()
+                            if (travelled <= -threshold) currentOnQueueClick()
                             travelled = 0f
                         },
                         onVerticalDrag = { change, dragAmount ->

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -21,9 +21,10 @@ import android.content.Intent
 import android.os.Build
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -64,6 +65,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -253,12 +255,12 @@ fun AppleMusicPlayerContent(
                 modifier =
                     Modifier
                         .matchParentSize()
-                        // 0..100 mapped onto a 60dp ceiling, matching the full-screen thumbnail
-                        // backdrop in Thumbnail.kt. Deliberately NOT the 25 that BackdropBlurApi30
-                        // uses: that radius is applied to a downscaled 500px bitmap, so 25 there is
-                        // a much stronger blur than 25dp across a full-screen image. Reusing 25 here
-                        // would leave API 31+ looking nearly unblurred next to older devices, and
-                        // well short of the 72dp this design originally hardcoded.
+                        // 0..100 mapped onto a 60dp ceiling, the same math Thumbnail.kt:559 uses for
+                        // its full-screen backdrop. Deliberately NOT the 25 BackdropBlurApi30 uses
+                        // internally: that radius applies to a small cached bitmap and is rescaled
+                        // along with it, so it is not in the same units as a dp radius spread across
+                        // a full-screen image. Reusing 25 here would leave API 31+ looking barely
+                        // blurred, and well short of the 72dp this design once hardcoded.
                         .blur((backdropBlurAmount * 60 / 100f).coerceIn(1f, 60f).dp),
             )
         } else {
@@ -469,20 +471,36 @@ private fun AppleMusicSharpArtwork(
                         },
                     )
                 }.pointerInput(Unit) {
+                    // Hand-rolled rather than detectVerticalDragGestures, which claims the gesture
+                    // on BOTH axes' slop and would swallow downward drags. BottomSheet runs its own
+                    // detectVerticalDragGestures, and this Box is its descendant, so a child that
+                    // consumes every vertical move stops the user from dragging the artwork down to
+                    // collapse the player. Only upward travel is consumed here; a downward drag is
+                    // left completely untouched so the sheet still receives it.
                     val threshold = AppleMusicSwipeThreshold.toPx()
-                    var travelled = 0f
-                    detectVerticalDragGestures(
-                        onDragStart = { travelled = 0f },
-                        onDragCancel = { travelled = 0f },
-                        onDragEnd = {
-                            if (travelled <= -threshold) currentOnQueueClick()
-                            travelled = 0f
-                        },
-                        onVerticalDrag = { change, dragAmount ->
-                            change.consume()
-                            travelled += dragAmount
-                        },
-                    )
+                    awaitEachGesture {
+                        val down = awaitFirstDown(requireUnconsumed = false)
+                        var travelled = 0f
+                        var opened = false
+                        while (true) {
+                            val event = awaitPointerEvent()
+                            val change = event.changes.firstOrNull { it.id == down.id } ?: break
+                            if (!change.pressed) break
+                            travelled += change.positionChange().y
+                            // Clearly heading down: bail out without ever consuming, leaving the
+                            // gesture to the sheet.
+                            if (!opened && travelled > threshold) break
+                            if (travelled <= -threshold) {
+                                if (!opened) {
+                                    opened = true
+                                    currentOnQueueClick()
+                                }
+                            }
+                            // Consume only once this is committed to being our swipe, so the sheet
+                            // does not also act on the same finger movement.
+                            if (opened) change.consume()
+                        }
+                    }
                 },
     ) {
         AsyncImage(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicSlider.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicSlider.kt
@@ -33,6 +33,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -76,6 +77,15 @@ internal fun AppleMusicFlatSlider(
     var dragging by remember { mutableStateOf(false) }
     var dragFraction by remember { mutableFloatStateOf(fraction) }
 
+    // The gesture blocks below are keyed on `enabled` alone, so anything they capture would
+    // otherwise be frozen at the composition that installed them. The seek bar's callback closes
+    // over the track duration, which changes on every song change -- a captured copy would keep
+    // converting taps against the previous song's length and seek to the wrong spot. Keying the
+    // pointerInput on the callbacks instead would cancel an in-flight drag whenever the position
+    // updated, so read them through rememberUpdatedState.
+    val currentOnFractionChange by rememberUpdatedState(onFractionChange)
+    val currentOnFractionChangeFinished by rememberUpdatedState(onFractionChangeFinished)
+
     val target = (if (dragging) dragFraction else fraction).coerceIn(0f, 1f)
     val animatedFraction by animateFloatAsState(
         targetValue = target,
@@ -105,8 +115,8 @@ internal fun AppleMusicFlatSlider(
                         // deliberately stays untouched -- writing it while dragging is false would
                         // leave a stale value that the next real drag animates away from.
                         val tapped = (offset.x / size.width).coerceIn(0f, 1f)
-                        onFractionChange(tapped)
-                        onFractionChangeFinished()
+                        currentOnFractionChange(tapped)
+                        currentOnFractionChangeFinished()
                     }
                 }.pointerInput(enabled) {
                     if (!enabled) return@pointerInput
@@ -114,17 +124,17 @@ internal fun AppleMusicFlatSlider(
                         onDragStart = { offset ->
                             dragging = true
                             dragFraction = (offset.x / size.width).coerceIn(0f, 1f)
-                            onFractionChange(dragFraction)
+                            currentOnFractionChange(dragFraction)
                         },
                         onDragEnd = {
                             dragging = false
-                            onFractionChangeFinished()
+                            currentOnFractionChangeFinished()
                         },
                         onDragCancel = { dragging = false },
                         onHorizontalDrag = { change, _ ->
                             change.consume()
                             dragFraction = (change.position.x / size.width).coerceIn(0f, 1f)
-                            onFractionChange(dragFraction)
+                            currentOnFractionChange(dragFraction)
                         },
                     )
                 }.drawBehind {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicSlider.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicSlider.kt
@@ -99,8 +99,12 @@ internal fun AppleMusicFlatSlider(
                 .pointerInput(enabled) {
                     if (!enabled) return@pointerInput
                     detectTapGestures { offset ->
+                        // Not setting `dragging` here: a tap has no press/release span to animate
+                        // over, so the fill should spring to the new value from wherever it is. It
+                        // reaches us through the caller's state on the next frame, so dragFraction
+                        // deliberately stays untouched -- writing it while dragging is false would
+                        // leave a stale value that the next real drag animates away from.
                         val tapped = (offset.x / size.width).coerceIn(0f, 1f)
-                        dragFraction = tapped
                         onFractionChange(tapped)
                         onFractionChangeFinished()
                     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicSlider.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicSlider.kt
@@ -1,0 +1,194 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ *
+ * Shared flat slider + volume row for the "Apple Music" player design.
+ *
+ * The player and the lyrics screen each used to carry their own volume slider — one a hand-drawn
+ * Canvas with no thumb, the other an M3 Slider with a zero-size invisible thumb. They looked
+ * subtly different and neither animated, so the fill snapped between values. Both now share this
+ * component so the two screens read as one control.
+ */
+
+package moe.rukamori.archivetune.ui.player
+
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.snap
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import moe.rukamori.archivetune.R
+
+private val AppleMusicSliderTouchHeight = 26.dp
+private val AppleMusicSliderIdleTrackHeight = 6.dp
+private val AppleMusicSliderPressedTrackHeight = 10.dp
+private val AppleMusicVolumeIconSize = 18.dp
+
+/**
+ * Flat Apple-Music-style slider: rounded track, no thumb, tap or drag anywhere to set the value.
+ *
+ * The track grows while held and settles back when released, which is what gives the control its
+ * "soft" feel. The fill is animated so a value arriving from outside (hardware volume keys, or
+ * playback progress) glides instead of jumping, but it snaps to the finger while dragging — an
+ * animated fill during a drag would lag behind the touch and feel broken.
+ */
+@Composable
+internal fun AppleMusicFlatSlider(
+    fraction: Float,
+    onFractionChange: (Float) -> Unit,
+    modifier: Modifier = Modifier,
+    onFractionChangeFinished: () -> Unit = {},
+    enabled: Boolean = true,
+    idleTrackHeight: Dp = AppleMusicSliderIdleTrackHeight,
+    pressedTrackHeight: Dp = AppleMusicSliderPressedTrackHeight,
+    trackColor: Color = Color.White.copy(alpha = 0.28f),
+    fillColor: Color = Color.White,
+) {
+    var dragging by remember { mutableStateOf(false) }
+    var dragFraction by remember { mutableFloatStateOf(fraction) }
+
+    val target = (if (dragging) dragFraction else fraction).coerceIn(0f, 1f)
+    val animatedFraction by animateFloatAsState(
+        targetValue = target,
+        animationSpec = if (dragging) snap() else spring(stiffness = Spring.StiffnessMediumLow),
+        label = "appleMusicSliderFraction",
+    )
+    val trackHeight by animateDpAsState(
+        targetValue = if (dragging) pressedTrackHeight else idleTrackHeight,
+        animationSpec = spring(dampingRatio = Spring.DampingRatioLowBouncy, stiffness = Spring.StiffnessMedium),
+        label = "appleMusicSliderTrackHeight",
+    )
+    val fillAlpha by animateFloatAsState(
+        targetValue = if (dragging) 1f else 0.85f,
+        label = "appleMusicSliderFillAlpha",
+    )
+
+    Box(
+        modifier =
+            modifier
+                .height(AppleMusicSliderTouchHeight)
+                .pointerInput(enabled) {
+                    if (!enabled) return@pointerInput
+                    detectTapGestures { offset ->
+                        val tapped = (offset.x / size.width).coerceIn(0f, 1f)
+                        dragFraction = tapped
+                        onFractionChange(tapped)
+                        onFractionChangeFinished()
+                    }
+                }.pointerInput(enabled) {
+                    if (!enabled) return@pointerInput
+                    detectHorizontalDragGestures(
+                        onDragStart = { offset ->
+                            dragging = true
+                            dragFraction = (offset.x / size.width).coerceIn(0f, 1f)
+                            onFractionChange(dragFraction)
+                        },
+                        onDragEnd = {
+                            dragging = false
+                            onFractionChangeFinished()
+                        },
+                        onDragCancel = { dragging = false },
+                        onHorizontalDrag = { change, _ ->
+                            change.consume()
+                            dragFraction = (change.position.x / size.width).coerceIn(0f, 1f)
+                            onFractionChange(dragFraction)
+                        },
+                    )
+                }.drawBehind {
+                    val height = trackHeight.toPx()
+                    val top = (size.height - height) / 2f
+                    val radius = CornerRadius(height / 2f)
+                    drawRoundRect(
+                        color = trackColor,
+                        topLeft = Offset(0f, top),
+                        size = Size(size.width, height),
+                        cornerRadius = radius,
+                    )
+                    drawRoundRect(
+                        color = fillColor.copy(alpha = fillColor.alpha * fillAlpha),
+                        topLeft = Offset(0f, top),
+                        size = Size(size.width * animatedFraction, height),
+                        cornerRadius = radius,
+                    )
+                },
+    )
+}
+
+/**
+ * Volume row used by both the Apple Music player and its lyrics screen.
+ *
+ * The left glyph switches to the muted speaker at zero so silence is visible at a glance; neither
+ * screen used to indicate mute at all.
+ */
+@Composable
+internal fun AppleMusicVolumeRow(
+    volume: Float,
+    onVolumeChange: (Float) -> Unit,
+    modifier: Modifier = Modifier,
+    iconTint: Color = Color.White.copy(alpha = 0.55f),
+    trackColor: Color = Color.White.copy(alpha = 0.28f),
+    fillColor: Color = Color.White,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier,
+    ) {
+        val muted = volume <= 0.001f
+        Icon(
+            painter =
+                painterResource(
+                    if (muted) R.drawable.player_volume_off else R.drawable.player_volume_min,
+                ),
+            contentDescription =
+                stringResource(
+                    if (muted) R.string.muted else R.string.minimum_volume,
+                ),
+            tint = iconTint,
+            modifier = Modifier.size(AppleMusicVolumeIconSize),
+        )
+        Spacer(Modifier.width(12.dp))
+        AppleMusicFlatSlider(
+            fraction = volume,
+            onFractionChange = onVolumeChange,
+            trackColor = trackColor,
+            fillColor = fillColor,
+            modifier = Modifier.weight(1f),
+        )
+        Spacer(Modifier.width(12.dp))
+        Icon(
+            painter = painterResource(R.drawable.player_volume_up),
+            contentDescription = stringResource(R.string.maximum_volume),
+            tint = iconTint,
+            modifier = Modifier.size(AppleMusicVolumeIconSize),
+        )
+    }
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
@@ -466,7 +466,17 @@ fun LyricsScreen(
     Box(
         modifier =
             modifier
-                .fillMaxSize(),
+                .fillMaxSize()
+                // Sits on the ROOT box, so it is a parent of both the scrim below and the lyrics
+                // Column above and therefore sees touches that land on either. The previous
+                // full-screen scrim was a SIBLING stacked underneath the lyrics, so the lyrics list
+                // won hit testing and swallowed every tap on a line -- only the narrow gaps around
+                // the text revealed the controls. This observes on the Initial pass and consumes
+                // nothing, so lyric scrolling and line seeking keep working untouched.
+                .observeAnyPointerDown(
+                    enabled = showPlayerControlsEnabled && autoHidePlayerControls,
+                    onDown = { pokePlayerControlsVisibility() },
+                ),
     ) {
         LyricsScreenBackground(
             style = lyricsBackground,
@@ -480,18 +490,14 @@ fun LyricsScreen(
             playerCustomBrightness = playerCustomBrightness,
         )
 
+        // Still needed to swallow taps that fall through to the background, so they do not reach
+        // whatever sits behind the lyrics sheet. The reveal poke it used to own now lives on the
+        // root Box above, which can actually see touches on the lyrics themselves.
         Box(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .consumeUnhandledPointerInput()
-                    .pointerInput(showPlayerControlsEnabled, autoHidePlayerControls) {
-                        if (!showPlayerControlsEnabled || !autoHidePlayerControls) return@pointerInput
-                        awaitEachGesture {
-                            awaitFirstDown(requireUnconsumed = false)
-                            pokePlayerControlsVisibility()
-                        }
-                    },
+                    .consumeUnhandledPointerInput(),
         )
 
         Column(
@@ -1058,39 +1064,19 @@ private fun AppleMusicControls(
                     )
                 }
 
-                Row(
+                // Shared with the Apple Music player itself so the two screens read as one
+                // control: animated fill, track that grows while held, and a muted glyph at zero.
+                AppleMusicVolumeRow(
+                    volume = volume.coerceIn(0f, 1f),
+                    onVolumeChange = onVolumeChange,
+                    iconTint = foregroundColor.copy(alpha = 0.66f),
+                    trackColor = foregroundColor.copy(alpha = 0.24f),
+                    fillColor = foregroundColor.copy(alpha = 0.88f),
                     modifier =
                         Modifier
                             .fillMaxWidth()
                             .padding(top = 26.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Icon(
-                        painter = painterResource(R.drawable.player_volume_min),
-                        contentDescription = stringResource(R.string.minimum_volume),
-                        tint = foregroundColor.copy(alpha = 0.66f),
-                        modifier = Modifier.size(17.dp),
-                    )
-                    AppleMusicSlider(
-                        value = volume.coerceIn(0f, 1f),
-                        valueRange = 0f..1f,
-                        activeColor = foregroundColor.copy(alpha = 0.88f),
-                        inactiveColor = foregroundColor.copy(alpha = 0.24f),
-                        trackHeight = 8.dp,
-                        onValueChange = onVolumeChange,
-                        onValueChangeFinished = {},
-                        modifier =
-                            Modifier
-                                .weight(1f)
-                                .padding(horizontal = 16.dp),
-                    )
-                    Icon(
-                        painter = painterResource(R.drawable.player_volume_up),
-                        contentDescription = stringResource(R.string.maximum_volume),
-                        tint = foregroundColor.copy(alpha = 0.66f),
-                        modifier = Modifier.size(19.dp),
-                    )
-                }
+                )
             }
         }
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -2157,8 +2157,13 @@ private fun V8PlayerBackdrop(
     }
 }
 
+// internal, not private: the Apple Music design reuses this instead of Modifier.blur(). A live
+// Modifier.blur() on a full-screen image re-runs the gaussian every frame, which made the lyrics
+// transition visibly choppy in that style only. This blurs once into a cached 500px bitmap off the
+// main thread, so per-frame cost is zero. Despite the name it is not API-gated — ImageBlurUtils is
+// a software blur, so it also gives older devices a backdrop they previously never got.
 @Composable
-private fun BackdropBlurApi30(
+internal fun BackdropBlurApi30(
     model: String?,
     blurAmount: Int,
     modifier: Modifier = Modifier,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PointerInputModifiers.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PointerInputModifiers.kt
@@ -29,8 +29,10 @@ internal fun Modifier.observeAnyPointerDown(
     enabled: Boolean,
     onDown: () -> Unit,
 ): Modifier {
-    // Keyed on `enabled` alone, so a fresh lambda from the caller cannot restart the handler on every
-    // recomposition; rememberUpdatedState keeps the callback current without being part of the key.
+    // pointerInput is keyed on Unit so a fresh lambda from the caller cannot restart the handler on
+    // every recomposition; rememberUpdatedState keeps the callback current without being a key.
+    // Toggling `enabled` is handled by swapping the modifier branch below, which tears the handler
+    // down and rebuilds it, so the key does not need to track it.
     val currentOnDown by rememberUpdatedState(onDown)
     return if (!enabled) {
         this

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PointerInputModifiers.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PointerInputModifiers.kt
@@ -7,9 +7,46 @@
 
 package moe.rukamori.archivetune.ui.player
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.changedToDownIgnoreConsumed
 import androidx.compose.ui.input.pointer.pointerInput
+
+/**
+ * Reports every touch that lands anywhere inside this node — including on scrolling children — and
+ * never consumes anything, so the children behave exactly as if this were not here.
+ *
+ * Apply this to a PARENT, not to an overlay sibling. A full-screen sibling stacked on top wins hit
+ * testing and starves the siblings beneath it even when it consumes nothing, which would stop the
+ * lyrics list from scrolling. A parent is in the hit path of all of its children, and the Initial
+ * pass runs before children see the event, so this observes without ever competing for the gesture.
+ */
+@Composable
+internal fun Modifier.observeAnyPointerDown(
+    enabled: Boolean,
+    onDown: () -> Unit,
+): Modifier {
+    // Keyed on `enabled` alone, so a fresh lambda from the caller cannot restart the handler on every
+    // recomposition; rememberUpdatedState keeps the callback current without being part of the key.
+    val currentOnDown by rememberUpdatedState(onDown)
+    return if (!enabled) {
+        this
+    } else {
+        pointerInput(Unit) {
+            awaitPointerEventScope {
+                while (true) {
+                    val event = awaitPointerEvent(PointerEventPass.Initial)
+                    if (event.changes.any { it.changedToDownIgnoreConsumed() }) {
+                        currentOnDown()
+                    }
+                }
+            }
+        }
+    }
+}
 
 internal fun Modifier.consumeUnhandledPointerInput(): Modifier =
     pointerInput(Unit) {

--- a/app/src/main/res/values/archivetune_strings.xml
+++ b/app/src/main/res/values/archivetune_strings.xml
@@ -255,6 +255,7 @@
     <string name="close">Close</string>
     <string name="minimum_volume">Minimum Volume</string>
     <string name="maximum_volume">Maximum Volume</string>
+    <string name="muted">Muted</string>
     <string name="hide_player_thumbnail">Hide Player Thumbnail</string>
     <string name="hide_player_thumbnail_desc">Replace album artwork with app logo in player</string>
     <string name="crop_thumbnail_to_square">Crop thumbnails to 1:1</string>


### PR DESCRIPTION
Verified green on CI (ktlint, unit tests, debug APK) at commit `a48f16e4` — run [30366880875](https://github.com/vossgraves/ArchiveTune/actions/runs/30366880875), 88MB APK artifact produced. Fast-forward onto `dev`, no commits overwritten.

## What was broken

- **Queue button did nothing.** The gesture that opens the queue was attached where it could never receive the touch. Moved onto the artwork, matching how the real app behaves.
- **Settings were silently ignored.** The player rendered its own hardcoded look instead of reading the prefs the rest of the app honours: `DisableBlurKey`, `BackdropEnabledKey`, `BackdropBlurAmountKey`, `ShowPlayerVolumeBarKey`, `PlayerButtonsStyleKey`, `SwipeThumbnailKey`.
- **Jank.** Sliders jumped between values rather than animating, and the volume slider could act on a stale fill value when tapped.
- **Blur was wrong on API 31+**, using 25dp where the rest of the app uses 60dp.

## Two regressions caught and fixed during review

- Moving the queue swipe onto the artwork initially **broke drag-to-collapse**. `detectVerticalDragGestures` claims the gesture on vertical slop in *either* direction and consumes every move; `BottomSheet` runs its own copy and this Box is its descendant, so the child won and the artwork could no longer be dragged down. The loop is now hand-rolled so only *upward* travel is consumed — a downward drag falls through to the sheet untouched.
- The shared slider's gesture blocks are keyed on `enabled` alone, so captured lambdas were pinned to the composition that installed them. The seek callback closes over track duration, which changes every song, so a stale copy would convert taps against the *previous* song's length and seek to the wrong spot. Callbacks now read through `rememberUpdatedState` (keying `pointerInput` on them instead would cancel an in-flight drag on every position tick).

## Cleanup

`AppleMusicSeekBar` was a second copy of the same control `AppleMusicFlatSlider` provides — identical colours, alpha and gestures, only the idle height differed — so it never got the animation work. It now delegates, keeping its 7dp idle track. Geometry is byte-for-byte preserved (26dp touch, 7dp idle, 10dp pressed).

## Two plan errors worth recording

- `PlayerTextAlignmentKey` **does not exist.** There is an orphaned `PlayerTextAlignment` enum in `AppearanceSettings.kt`, but no preference key, no settings UI, no string resources, and nothing reads it. Honouring it would mean inventing a setting rather than respecting one.
- `BlurRadiusKey` is scoped to the lyrics-sheet background, not player backdrops — hence `BackdropEnabledKey`/`BackdropBlurAmountKey`, matching `Thumbnail.kt`.

GPL-3.0 headers (`© Rukamori`) preserved on all new files.