### PR TITLE
fix(sync): unblock upstream sync and harden the kimi-k2.6 resolver

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -130,24 +130,32 @@ jobs:
           CANVAS_BEARER_TOKEN: ${{ secrets.CANVAS_BEARER_TOKEN }}
           EXTRACTOR_BEARER: ${{ secrets.EXTRACTOR_BEARER }}
 
-      - name: Open sync PR (AI-resolved sync)
-        if: steps.sync.outputs.result == 'ai'
+      # `raced` is a clean merge that passed the build gate but could not fast-forward dev
+      # because dev advanced during the run. It ships down the same self-merging PR path.
+      - name: Open sync PR (AI-resolved or raced sync)
+        if: steps.sync.outputs.result == 'ai' || steps.sync.outputs.result == 'raced'
         env:
           GH_TOKEN: ${{ secrets.SYNC_PAT }}
           SYNC_BRANCH: ${{ steps.sync.outputs.branch }}
           BEHIND: ${{ steps.sync.outputs.behind }}
+          RESULT: ${{ steps.sync.outputs.result }}
         run: |
+          if [ "$RESULT" = "raced" ]; then
+            TITLE="chore(sync): merge upstream/dev ($BEHIND commits, dev moved mid-run)"
+          else
+            TITLE="chore(sync): merge upstream/dev ($BEHIND commits, AI-resolved)"
+          fi
           PR_URL=$(gh pr create \
             --repo "$GITHUB_REPOSITORY" \
             --base dev \
             --head "$SYNC_BRANCH" \
-            --title "chore(sync): merge upstream/dev ($BEHIND commits, AI-resolved)" \
+            --title "$TITLE" \
             --body-file /tmp/sync_report.md)
           echo "Opened PR: $PR_URL"
           gh pr comment --repo "$GITHUB_REPOSITORY" "$PR_URL" --body "This PR will be merged automatically by the 'Upstream Sync Merge' workflow once the Build Pull Request CI passes. No action needed unless CI fails."
 
       - name: Report successful sync
-        if: steps.sync.outputs.result == 'clean' || steps.sync.outputs.result == 'ai'
+        if: steps.sync.outputs.result == 'clean' || steps.sync.outputs.result == 'ai' || steps.sync.outputs.result == 'raced'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.SYNC_PAT }}

--- a/scripts/ai_resolve.py
+++ b/scripts/ai_resolve.py
@@ -6,7 +6,7 @@ Usage (from the repo root of the conflicted checkout):
 
 Providers (in priority order):
   1. Custom OpenAI-compatible endpoint (env AI_BASE_URL, AI_API_KEY, AI_MODEL)
-     — e.g. OpenCode Go (https://opencode.ai/zen/go/v1) with kimi-k3.
+     — NVIDIA NIM (https://integrate.api.nvidia.com/v1) with moonshotai/kimi-k2.6.
   2. GitHub Models free tier (env MODELS_TOKEN) — fallback chain:
      openai/gpt-4.1 -> openai/gpt-4.1-mini -> openai/gpt-4o-mini
 
@@ -45,12 +45,24 @@ def build_providers():
     providers = []
     base = os.environ.get("AI_BASE_URL", "").rstrip("/")
     key = os.environ.get("AI_API_KEY", "")
-    model = os.environ.get("AI_MODEL", "kimi-k3")
+    model = os.environ.get("AI_MODEL", "moonshotai/kimi-k2.6")
     if base and key:
-        # Note: the OpenCode Go gateway rejects a `temperature` field for
-        # kimi models — leave it unset there.
+        # `temperature` is deliberately left unset, and MUST stay unset for kimi-k2.6 on
+        # NIM: that model pins its own sampling and returns an ERROR if a temperature
+        # field is sent at all. Its fixed value depends on the thinking mode -- 1.0 with
+        # thinking on, 0.6 with it off -- so turning thinking OFF is the only lever we
+        # have to reduce randomness, which is what we want for a mechanical conflict edit.
+        # Disabling it also stops the reasoning from competing with the answer for the
+        # max_tokens budget, which is what produced truncated (and empty) responses.
+        #
+        # Both extras are best-effort: call_llm retries without them if the endpoint
+        # rejects the fields, so an API change degrades to a working request, not a
+        # failed sync. max_tokens follows NVIDIA's guidance for this model (16k floor,
+        # 32k recommended); the previous 8000 sat under the floor.
         providers.append({"base": base, "key": key, "models": [model],
-                          "max_tokens": 8000, "temperature": None})
+                          "max_tokens": 32768, "temperature": None,
+                          "extra": {"chat_template_kwargs": {"thinking": False},
+                                    "include_reasoning": False}})
     token = os.environ.get("MODELS_TOKEN", "")
     if token:
         providers.append({
@@ -63,42 +75,77 @@ def build_providers():
     return providers
 
 
+NET_ERRORS = (urllib.error.URLError, urllib.error.HTTPError, ValueError,
+              KeyError, IndexError, json.JSONDecodeError, TimeoutError)
+
+
+def post_completion(provider, model, system, user, extras):
+    """One chat/completions call. Returns the answer, or raises on any bad response."""
+    body = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ],
+        "max_tokens": provider["max_tokens"],
+    }
+    if provider.get("temperature") is not None:
+        body["temperature"] = provider["temperature"]
+    body.update(extras)
+    req = urllib.request.Request(
+        provider["base"] + "/chat/completions",
+        data=json.dumps(body).encode(),
+        headers={
+            "Authorization": "Bearer " + provider["key"],
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            # Some gateways reject the default urllib UA outright.
+            "User-Agent": "archivetune-sync/1.0",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
+        data = json.loads(resp.read().decode())
+    choice = data["choices"][0]
+    text = choice["message"]["content"]
+    # A reasoning model that burns its whole token budget on thinking still answers
+    # 200 OK -- with finish_reason=length and an empty content field. Both cases must
+    # raise, because returning them would hand resolve_file an empty replacement and
+    # that gets spliced over the conflict as a silent deletion.
+    if choice.get("finish_reason") == "length":
+        raise ValueError("response truncated (finish_reason=length)")
+    if text is None or not text.strip():
+        raise ValueError("empty content in response")
+    return text
+
+
 def call_llm(system, user):
     last_err = "no providers configured"
     for provider in build_providers():
         for model in provider["models"]:
-            body = {
-                "model": model,
-                "messages": [
-                    {"role": "system", "content": system},
-                    {"role": "user", "content": user},
-                ],
-                "max_tokens": provider["max_tokens"],
-            }
-            if provider.get("temperature") is not None:
-                body["temperature"] = provider["temperature"]
-            payload = json.dumps(body).encode()
-            req = urllib.request.Request(
-                provider["base"] + "/chat/completions",
-                data=payload,
-                headers={
-                    "Authorization": "Bearer " + provider["key"],
-                    "Content-Type": "application/json",
-                    "Accept": "application/json",
-                    # Some gateways (OpenCode Go) reject default python UA.
-                    "User-Agent": "opencode/1.0",
-                },
-            )
-            try:
-                with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
-                    data = json.loads(resp.read().decode())
-                text = data["choices"][0]["message"]["content"]
-                print(f"[ai] resolved via {model}", file=sys.stderr)
-                return text
-            except (urllib.error.URLError, urllib.error.HTTPError,
-                    KeyError, IndexError, json.JSONDecodeError, TimeoutError) as exc:
-                last_err = f"{model}: {exc}"
-                print(f"[ai] {provider['base']} {last_err} — trying next", file=sys.stderr)
+            # Try the tuned request first, then a bare one. The extras are documented for
+            # this model today, but an unrecognised field is a 400 on most OpenAI-compatible
+            # endpoints, and failing outright would mean a conflicted sync gets no AI help
+            # at all. Losing the tuning is a far better outcome than losing the request.
+            extras = provider.get("extra") or {}
+            for attempt in ([extras, {}] if extras else [{}]):
+                try:
+                    text = post_completion(provider, model, system, user, attempt)
+                    # Only say "untuned" when tuning existed and was dropped -- providers
+                    # that never had extras (GitHub Models) are not retries.
+                    dropped = bool(extras) and not attempt
+                    print(f"[ai] resolved via {model}"
+                          f"{' (untuned retry)' if dropped else ''}", file=sys.stderr)
+                    return text
+                except NET_ERRORS as exc:
+                    last_err = f"{model}: {exc}"
+                    print(f"[ai] {provider['base']} {last_err} — trying next",
+                          file=sys.stderr)
+                    # Only the tuned attempt is worth retrying bare. Anything that is not a
+                    # rejected-field error (auth, rate limit, outage) will fail identically
+                    # without the extras, so skip straight to the next model.
+                    status = getattr(exc, "code", None)
+                    if attempt and status not in (400, 422):
+                        break
     print(f"[ai] ALL providers failed ({last_err})", file=sys.stderr)
     return None
 
@@ -159,6 +206,13 @@ def resolve_file(path):
         if answer is None:
             return False
         replacement = strip_fences(answer)
+        # Never let an empty answer through. Splicing "" over the hunk deletes BOTH sides
+        # and leaves no conflict markers behind, so the run would report success while
+        # having quietly dropped whatever fork feature lived in that hunk. call_llm already
+        # rejects empty content; this is the backstop that makes the deletion unreachable.
+        if not replacement.strip():
+            print(f"[ai] empty resolution for {path} — rejecting", file=sys.stderr)
+            return False
         if re.search(r"^(<<<<<<<|=======|>>>>>>>)", replacement, re.MULTILINE):
             print(f"[ai] model emitted markers for {path} — rejecting", file=sys.stderr)
             return False

--- a/scripts/upstream_sync.sh
+++ b/scripts/upstream_sync.sh
@@ -8,7 +8,8 @@
 #   4. Merge upstream/dev into dev (AI resolves conflicts per the constitution)
 #   5. Verify: no markers, protected files untouched, fork features intact
 #   6. Build gate: assembleGmsMobileUniversalDebug must succeed
-#   7. Deliver: clean merge -> push dev; AI-resolved -> push sync branch (PR opened by workflow)
+#   7. Deliver: clean merge -> push dev; AI-resolved, or clean but dev moved mid-run ->
+#      push sync/auto-* branch (PR opened by workflow, self-merges when CI is green)
 #
 # Required env: SYNC_PAT, GH_TOKEN
 # Optional env: AI_API_KEY, AI_BASE_URL, AI_MODEL, MODELS_TOKEN
@@ -224,16 +225,34 @@ log "build OK"
 log "Phase 6: deliver"
 # =============================================================================
 SYNC_BRANCH=""
+RESULT=""
 if $AI_USED; then
   SYNC_BRANCH="sync/auto-$(date -u +%Y%m%d-%H%M)"
   git push --quiet origin "HEAD:$SYNC_BRANCH" || die "could not push $SYNC_BRANCH"
+  RESULT="ai"
   out "result" "ai"
   out "branch" "$SYNC_BRANCH"
   log "AI-resolved merge pushed to $SYNC_BRANCH (PR will self-merge when CI passes)"
-else
-  git push --quiet origin HEAD:dev || die "could not push to dev"
+elif git push --quiet origin HEAD:dev 2>/dev/null; then
+  RESULT="clean"
   out "result" "clean"
   log "clean merge pushed straight to dev"
+else
+  # dev moved while this run was in flight. The build gate above takes ~10 minutes and this
+  # job fires hourly, so any human push or PR merge inside that window used to land here and
+  # `die`, discarding a merge that had already passed the contract tests AND assembled. The
+  # merge was never wrong; it was just built on a dev tip that no longer exists.
+  #
+  # Re-merging the new tip here and pushing anyway would put an unverified tree on dev,
+  # because the build gate has already run. So deliver it exactly like an AI-resolved merge:
+  # a sync/auto-* branch plus a PR, which re-runs CI against the current dev and self-merges
+  # when green. The sync/auto- prefix is what Upstream Sync Merge keys on, so it must stay.
+  SYNC_BRANCH="sync/auto-$(date -u +%Y%m%d-%H%M)"
+  git push --quiet origin "HEAD:$SYNC_BRANCH" || die "could not push $SYNC_BRANCH after dev moved"
+  RESULT="raced"
+  out "result" "raced"
+  out "branch" "$SYNC_BRANCH"
+  log "dev moved mid-run; delivered as $SYNC_BRANCH (PR will self-merge when CI passes)"
 fi
 
 # =============================================================================
@@ -242,7 +261,11 @@ log "Phase 7: report"
 {
   echo "## Upstream sync report ($(date -u +%Y-%m-%dT%H:%MZ))"
   echo
-  echo "- **Result:** $($AI_USED && echo 'AI-resolved, delivered as self-merging PR' || echo 'clean, pushed to dev')"
+  case "$RESULT" in
+    ai)    echo "- **Result:** AI-resolved, delivered as self-merging PR" ;;
+    raced) echo "- **Result:** clean merge, but \`dev\` advanced mid-run — delivered as a self-merging PR instead of pushing to \`dev\`" ;;
+    *)     echo "- **Result:** clean, pushed to dev" ;;
+  esac
   echo "- **Pulled in:** $BEHIND commit(s) from [rukamori/ArchiveTune@dev](https://github.com/rukamori/ArchiveTune/tree/dev)"
   echo "- **Backup branch:** \`$BACKUP_BRANCH\`"
   [ -n "$SYNC_BRANCH" ] && echo "- **Sync branch:** \`$SYNC_BRANCH\`"
@@ -279,5 +302,5 @@ log "Phase 7: report"
   echo '```'
 } > "$REPORT"
 
-log "done ($($AI_USED && echo ai || echo clean))"
+log "done ($RESULT)"
 exit 0


### PR DESCRIPTION
## The workflow was not broken by kimi or NIM

Worth stating up front, since that was the starting assumption: `moonshotai/kimi-k2.6` at `https://integrate.api.nvidia.com/v1` is a valid model ID, the resolver posts to the right path, and **the AI resolver was never reached in any failing run**. Two unrelated things were breaking sync.

### 1. Three runs failed the fork contract tests

`03:37`, `06:41`, `09:48` all died on `AssertionError at TitleMatchTest.kt:21`. That test was **already fixed** in `61a8ed3e8` — a commit that was sitting unpushed, so every run kept merging onto a `dev` that lacked the fix. Landing it resolved these. (The old line 21 asserted the rejection reason contained `"artist"`, but the 15s duration gate fires first and returns a duration reason. The fix asserts on rejection, not on which gate rejected.)

This is also why the expired-OpenCode-subscription theory does not hold: `TitleMatchTest` is a pure offline JUnit test with no network calls, so no subscription can affect it.

### 2. The real remaining bug — Phase 6 threw away verified work

The `12:14` run **passed the contract tests and assembled the APK**, then died on:

```
! [rejected] HEAD -> dev (fetch first)
```

Phase 6 was `git push origin HEAD:dev || die`. The build gate takes ~10 minutes and the job runs hourly, so any push or PR merge inside that window killed a merge that had already been fully verified. Nothing was wrong with the merge — it was just built on a `dev` tip that no longer existed.

Phase 6 now treats a rejected push as a first-class `raced` outcome. Re-merging and pushing there would put an **unverified** tree on `dev` (the build gate has already run), so it is delivered down the existing `sync/auto-*` PR path, which re-runs CI against the current `dev` and self-merges when green. The `sync/auto-` prefix is what `Upstream Sync Merge` keys on, so it is preserved.

## Latent resolver bugs from the provider swap

These would only have surfaced on the first real conflict — and no `sync/auto-*` branch has ever existed, so the NIM path had never actually run.

- **`max_tokens` was 8000**, under NVIDIA's 16k floor for this model. kimi-k2.6 reasons by default and that reasoning shares the budget with the answer, so a non-trivial hunk came back truncated — or with an empty `content` field on a `200 OK`. Now 32768.
- **An empty answer was spliced straight over the conflict hunk.** That removes *both* sides and leaves no markers behind, so the run reported success having silently deleted whatever fork feature lived there. Reproduced against a synthetic conflict: the old code dropped a `TidalProvider()` line and returned `success: True`. Now rejected in `call_llm` (`finish_reason=length`, blank/null content) and again in `resolve_file`.
- **Stale OpenCode references**: default `AI_MODEL` was still `kimi-k3`, plus the docstring and `User-Agent`.

## On determinism

Deterministic output was requested, but it is not achievable for this model: kimi-k2.6 on NIM **pins its own sampling and errors if a `temperature` field is sent at all**. Its fixed value is 0.6 with thinking off versus 1.0 with thinking on, so disabling thinking via `chat_template_kwargs` is the only available lever — and it also stops reasoning from competing for the token budget. The existing `temperature: 0.1` on the GitHub Models fallback is untouched.

Both extras are best-effort: a `400`/`422` retries once without them, so a future API change degrades to a working request instead of a failed sync. A non-field error (auth, rate limit) skips that pointless retry.

## Verification

Resolver paths were exercised against a synthetic conflict with a mocked transport: tuned request accepted; `400` on extras falling back to a bare retry; `401` not wasting a retry; truncation and empty content failing closed with the file left byte-identical; NIM truncation falling through to GitHub Models; and a valid resolution still applying with markers gone. Phase 6 was simulated for both the clean and rejected push paths. `bash -n`, `py_compile`, and a real YAML parse all pass.

Worth noting the sync path still has no end-to-end test — an actual upstream conflict is the first real exercise of it.