### PR TITLE
Add pool-backed Deezer stream resolution and Blowfish decryption

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/App.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/App.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
 import moe.rukamori.archivetune.canvas.ArchiveTuneCanvas
 import moe.rukamori.archivetune.constants.*
+import moe.rukamori.archivetune.deezer.DeezerAudioProvider
 import moe.rukamori.archivetune.extensions.*
 import moe.rukamori.archivetune.gatekeeper.GatekeeperResult
 import moe.rukamori.archivetune.gatekeeper.RunGatekeeperCheckUseCase
@@ -342,6 +343,18 @@ class App :
                     } else {
                         YouTube.dns = Dns.SYSTEM
                     }
+                }
+        }
+
+        // Mirrors the manually signed-in Deezer account into the provider. A collector rather than a
+        // one-shot read so signing in or out takes effect immediately, and so the value survives the
+        // pool refresh that replaces the pooled account cache.
+        applicationScope.launch(Dispatchers.IO) {
+            dataStore.data
+                .map { (it[DeezerArlKey] ?: "") to (it[DeezerAccountPremiumKey] ?: false) }
+                .distinctUntilChanged()
+                .collect { (arl, premium) ->
+                    DeezerAudioProvider.setManualArl(arl, premium)
                 }
         }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/audiosource/AudioSourceConfig.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/audiosource/AudioSourceConfig.kt
@@ -263,6 +263,7 @@ object AudioSourceConfig {
         listOf(
             AudioSourceType.TIDAL,
             AudioSourceType.QOBUZ,
+            AudioSourceType.DEEZER,
             AudioSourceType.YOUTUBE,
         )
 
@@ -287,8 +288,11 @@ object AudioSourceConfig {
                 ?.distinct()
                 .orEmpty()
         val merged = LinkedHashSet(parsed)
-        // Append any sources not present in the stored order in their default position. When nothing
-        // is stored this yields DEFAULT_ORDER (Tidal, Qobuz, YouTube), i.e. YouTube stays last.
+        // Append any sources not present in the stored order. When nothing is stored this yields
+        // DEFAULT_ORDER (Tidal, Qobuz, Deezer, YouTube), i.e. YouTube stays last. Note a source added
+        // by a later app update lands at the END for users who already have an order stored, even if
+        // DEFAULT_ORDER puts it before YouTube — deliberately, so an update never silently promotes a
+        // new source above the stream a user already had configured.
         DEFAULT_ORDER.forEach { merged.add(it) }
         return merged.toList()
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/audiosource/TrackMatching.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/audiosource/TrackMatching.kt
@@ -1,0 +1,189 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ */
+
+package moe.rukamori.archivetune.audiosource
+
+import java.text.Normalizer
+import java.util.Locale
+import kotlin.math.abs
+
+/**
+ * Shared heuristics for deciding whether a catalog search hit is actually the track we asked for.
+ *
+ * Every lossless provider searches a third-party catalog by text and has to judge the results, so the
+ * same scoring is needed by each one. `TidalAudioProvider` and `QobuzAudioProvider` predate this file
+ * and still carry their own private copies of these functions; this exists so Deezer did not become a
+ * third copy. Migrating those two onto this object is a mechanical but behaviour-visible change to
+ * working providers, so it is deliberately left as its own future change rather than bundled into the
+ * commit that adds Deezer.
+ *
+ * The thresholds here are copied from those providers verbatim so all three sources agree on what
+ * counts as a match.
+ */
+internal object TrackMatching {
+    /** Minimum score for a candidate to be accepted at all. */
+    const val MIN_MATCH_SCORE = 60
+
+    /** Ignored when comparing token sets, since they carry no identifying information. */
+    private val STOP_WORDS = setOf("the", "a", "an", "of", "and", "feat", "ft", "featuring", "with")
+
+    /**
+     * Words that distinguish otherwise identically-titled recordings. A mismatch on any of these is
+     * treated as a hard rejection, because serving a live take for a studio track is worse than
+     * serving nothing and falling through to the next source.
+     */
+    private val VERSION_TOKENS =
+        setOf("remix", "acoustic", "live", "instrumental", "demo", "edit", "mix", "version")
+
+    /** Runtimes this far apart are still considered the same recording. */
+    private const val DURATION_TOLERANCE_MS = 45_000L
+
+    /**
+     * Scores [candidateTitle]/[candidateArtist] against what we wanted. Returns [Int.MIN_VALUE] for a
+     * hard rejection; otherwise higher is better and callers should require [MIN_MATCH_SCORE].
+     */
+    fun score(
+        wantedTitle: String,
+        wantedArtists: List<String>,
+        candidateTitle: String,
+        candidateArtist: String,
+        wantedDurationMs: Long?,
+        candidateDurationMs: Long?,
+    ): Int {
+        if (wantedTitle.isBlank() || candidateTitle.isBlank()) return Int.MIN_VALUE
+        if (hasVersionMismatch(" $wantedTitle ", " $candidateTitle ")) return Int.MIN_VALUE
+        val titleOverlap = tokenOverlap(significantTokens(wantedTitle), significantTokens(candidateTitle))
+        if (titleOverlap < 0.5) return Int.MIN_VALUE
+        var score = (titleOverlap * 100).toInt()
+        if (wantedArtists.isNotEmpty() && candidateArtist.isNotBlank()) {
+            val artistOverlap =
+                wantedArtists.maxOf { tokenOverlap(significantTokens(it), significantTokens(candidateArtist)) }
+            score += (artistOverlap * 60).toInt()
+        }
+        if (wantedDurationMs != null && candidateDurationMs != null) {
+            // A duration agreement is weak evidence but a disagreement is strong counter-evidence, so
+            // the penalty deliberately outweighs the bonus.
+            if (durationMatches(wantedDurationMs, candidateDurationMs)) score += 30 else score -= 40
+        }
+        return score
+    }
+
+    /** What the player asked for. */
+    data class Target(
+        val title: String,
+        val artists: List<String>,
+        val album: String?,
+        val durationMs: Long?,
+    )
+
+    /**
+     * One search hit from a provider's catalog, normalized so [best] can rank hits from any source.
+     * [id] is the provider's own track identifier and is opaque here.
+     */
+    data class Candidate(
+        val id: String,
+        val title: String,
+        val artists: List<String>,
+        val album: String?,
+        val durationMs: Long?,
+    )
+
+    /**
+     * Picks the highest-scoring candidate that clears [MIN_MATCH_SCORE], or null when none does.
+     *
+     * Returning null is the intended outcome for a track the catalog does not carry: the caller falls
+     * through to the next source rather than playing a wrong recording. Note this is only the
+     * provider-internal choice of "which hit is best" — the playback layer still re-checks the winner
+     * with [TitleMatch], so a provider cannot bypass the shared safety gate by scoring loosely here.
+     */
+    fun best(
+        target: Target,
+        candidates: List<Candidate>,
+    ): Candidate? =
+        candidates
+            .asSequence()
+            .map { candidate ->
+                candidate to
+                    score(
+                        wantedTitle = normalizeTitle(target.title),
+                        wantedArtists = target.artists.map { normalize(it) },
+                        candidateTitle = normalizeTitle(candidate.title),
+                        candidateArtist = normalize(candidate.artists.firstOrNull()),
+                        wantedDurationMs = target.durationMs,
+                        candidateDurationMs = candidate.durationMs,
+                    )
+            }.filter { (_, score) -> score >= MIN_MATCH_SCORE }
+            .maxByOrNull { (_, score) -> score }
+            ?.first
+
+    private fun significantTokens(value: String): Set<String> =
+        value
+            .split(' ')
+            .map { it.trim() }
+            .filter { it.length >= 2 && it !in STOP_WORDS }
+            .toSet()
+
+    private fun tokenOverlap(
+        wanted: Set<String>,
+        candidate: Set<String>,
+    ): Double {
+        if (wanted.isEmpty() || candidate.isEmpty()) return 0.0
+        val shared = wanted.intersect(candidate).size
+        // Divide by the larger set so that a candidate padded with extra words cannot score a perfect
+        // overlap just by containing every wanted token.
+        return shared.toDouble() / wanted.size.coerceAtLeast(candidate.size).toDouble()
+    }
+
+    fun durationMatches(
+        wantedDurationMs: Long?,
+        candidateDurationMs: Long?,
+    ): Boolean {
+        if (wantedDurationMs == null || candidateDurationMs == null) return true
+        return abs(wantedDurationMs - candidateDurationMs) <= DURATION_TOLERANCE_MS
+    }
+
+    private fun hasVersionMismatch(
+        wanted: String,
+        candidate: String,
+    ): Boolean = VERSION_TOKENS.any { token -> wanted.contains(" $token ") != candidate.contains(" $token ") }
+
+    /** Lowercased, accent-stripped, punctuation-collapsed form used for all token comparisons. */
+    fun normalize(value: String?): String =
+        value
+            ?.lowercase(Locale.US)
+            ?.let { Normalizer.normalize(it, Normalizer.Form.NFD) }
+            ?.replace(Regex("\\p{Mn}+"), "")
+            ?.replace(Regex("[^a-z0-9]+"), " ")
+            ?.trim()
+            .orEmpty()
+
+    /** Strips featured-artist and edition noise that catalogs disagree about. */
+    fun normalizeTitle(value: String): String =
+        normalize(value)
+            .replace(Regex("""\b(feat|ft|featuring)\b.*$"""), "")
+            .replace(Regex("""\b(explicit|clean|remaster|remastered|version|audio|official)\b"""), " ")
+            .replace(Regex("\\s+"), " ")
+            .trim()
+
+    /** Cleans a title for use as a search query, keeping original casing and diacritics. */
+    fun searchTitle(value: String): String =
+        value
+            .trim()
+            .replace(Regex("""\s*[\[(]\s*(feat\.?|ft\.?|featuring)\b.*?[\])]""", RegexOption.IGNORE_CASE), "")
+            .replace(
+                Regex("""\s*-\s*(explicit|clean|remaster(?:ed)?|audio|official)\b.*$""", RegexOption.IGNORE_CASE),
+                "",
+            ).replace(Regex("\\s+"), " ")
+            .trim()
+
+    /** Primary artist only; catalogs list collaborators inconsistently. */
+    fun searchArtist(value: String): String =
+        value
+            .trim()
+            .substringBefore(',')
+            .replace(Regex("\\s+"), " ")
+            .trim()
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -963,9 +963,22 @@ fun QobuzAudioQuality.toFormatId(): Int =
 // Deezer source
 // ---------------------------------------------------------------------------
 // Unlike Tidal/Qobuz there is no self-hosted proxy tier: Deezer streams come from accounts
-// authenticated with an `arl` cookie, supplied by the pool. Defaults OFF because the source is inert
-// without accounts.
+// authenticated with an `arl` cookie, supplied by the pool or by a manual sign-in. Defaults OFF
+// because the source is inert without accounts.
 val DeezerEnabledKey = booleanPreferencesKey("deezerEnabled")
+
+// A manually captured `arl` cookie. Kept separate from the pool cache: the pool is wiped and
+// rewritten on every refresh and is gated behind PoolAccountManager.isEnabled, so storing a
+// user's own credential there would lose it on the next sync.
+val DeezerArlKey = stringPreferencesKey("deezerArl")
+
+// Display label for the manually signed-in account, so the settings row can say who is signed in
+// without keeping the ARL itself anywhere near the UI.
+val DeezerAccountNameKey = stringPreferencesKey("deezerAccountName")
+
+// Whether the manual account reported a lossless-capable plan. Only orders resolution attempts;
+// the provider still verifies the real tier per track.
+val DeezerAccountPremiumKey = booleanPreferencesKey("deezerAccountPremium")
 
 // Deezer serves three tiers. FLAC needs a lossless plan, so the provider walks down from the
 // requested tier and a free account silently lands on MP3 rather than failing the track.

--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -176,6 +176,7 @@ enum class DownloadSource {
     AUTO,
     QOBUZ,
     TIDAL,
+    DEEZER,
     YOUTUBE_MUSIC,
     ;
 
@@ -185,9 +186,12 @@ enum class DownloadSource {
      */
     fun losslessChain(): List<DownloadSource> =
         when (this) {
-            AUTO -> listOf(QOBUZ, TIDAL)
+            // Deezer is tried last: it is inert without pooled accounts, so putting it ahead of
+            // Qobuz/Tidal would just add a wasted round trip for the many users who have none.
+            AUTO -> listOf(QOBUZ, TIDAL, DEEZER)
             QOBUZ -> listOf(QOBUZ)
             TIDAL -> listOf(TIDAL)
+            DEEZER -> listOf(DEEZER)
             YOUTUBE_MUSIC -> emptyList()
         }
 }
@@ -1013,6 +1017,9 @@ val TelegramLosslessOnlyKey = booleanPreferencesKey("telegramLosslessOnly")
 enum class AudioSourceType {
     TIDAL,
     QOBUZ,
+    DEEZER,
+
+    // Must stay last: the resolution chain treats everything after YOUTUBE as "not an override".
     YOUTUBE,
 }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -956,6 +956,39 @@ fun QobuzAudioQuality.toFormatId(): Int =
     }
 
 // ---------------------------------------------------------------------------
+// Deezer source
+// ---------------------------------------------------------------------------
+// Unlike Tidal/Qobuz there is no self-hosted proxy tier: Deezer streams come from accounts
+// authenticated with an `arl` cookie, supplied by the pool. Defaults OFF because the source is inert
+// without accounts.
+val DeezerEnabledKey = booleanPreferencesKey("deezerEnabled")
+
+// Deezer serves three tiers. FLAC needs a lossless plan, so the provider walks down from the
+// requested tier and a free account silently lands on MP3 rather than failing the track.
+enum class DeezerAudioQuality {
+    FLAC,
+    MP3_320,
+    MP3_128,
+}
+
+val DeezerAudioQualityOptions =
+    listOf(
+        DeezerAudioQuality.FLAC,
+        DeezerAudioQuality.MP3_320,
+        DeezerAudioQuality.MP3_128,
+    )
+
+val DeezerAudioQualityKey = stringPreferencesKey("deezerAudioQuality")
+
+/** The `format` string Deezer's media endpoint expects for each tier. */
+fun DeezerAudioQuality.toFormatName(): String =
+    when (this) {
+        DeezerAudioQuality.FLAC -> "FLAC"
+        DeezerAudioQuality.MP3_320 -> "MP3_320"
+        DeezerAudioQuality.MP3_128 -> "MP3_128"
+    }
+
+// ---------------------------------------------------------------------------
 // Telegram channel streaming integration
 // ---------------------------------------------------------------------------
 // Streams audio files (lossless-first) directly from Telegram channels via TDLib. The user logs in

--- a/app/src/main/kotlin/moe/rukamori/archivetune/deezer/DeezerAudioProvider.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/deezer/DeezerAudioProvider.kt
@@ -69,6 +69,87 @@ object DeezerAudioProvider {
             .callTimeout(15, TimeUnit.SECONDS)
             .build()
 
+    /**
+     * A manually captured ARL, set by the Deezer login screen and mirrored from DataStore on startup.
+     * Held here rather than in [PoolAccountManager] because that cache is replaced wholesale on every
+     * pool refresh and is gated behind `isEnabled`, either of which would drop a user's own account.
+     */
+    @Volatile
+    private var manualAccount: PoolAccountManager.DeezerPoolAccount? = null
+
+    /**
+     * Registers (or clears, on null/blank) the manually signed-in account. Cheap and idempotent, so
+     * call sites can push the current value without tracking whether it changed.
+     */
+    fun setManualArl(
+        arl: String?,
+        premium: Boolean = false,
+    ) {
+        val trimmed = arl?.trim()
+        val next =
+            if (trimmed.isNullOrEmpty()) {
+                null
+            } else {
+                // masterSecret stays null: only the pool serves an override, and DeezerCrypto falls
+                // back to the salt the app ships with.
+                PoolAccountManager.DeezerPoolAccount(arl = trimmed, premium = premium)
+            }
+        val previous = manualAccount
+        manualAccount = next
+        // Sessions are keyed by ARL, so a changed or removed credential must not keep serving from a
+        // session established under the old one.
+        if (previous != null && previous.arl != next?.arl) {
+            sessions.remove(previous.arl)
+        }
+    }
+
+    /**
+     * Every usable credential, manual first so a user's own (likely paid) account is tried before
+     * shared pool entries.
+     */
+    private fun accounts(): List<PoolAccountManager.DeezerPoolAccount> {
+        val pooled = PoolAccountManager.deezerAccounts()
+        val manual = manualAccount ?: return pooled
+        // Drop a pooled duplicate so one bad credential cannot be attempted twice per resolve.
+        return listOf(manual) + pooled.filter { it.arl != manual.arl }
+    }
+
+    /** What a manual sign-in learns about the account behind an ARL. */
+    data class AccountInfo(
+        val name: String,
+        val lossless: Boolean,
+    )
+
+    /**
+     * Checks an ARL against the gateway and reports the account behind it, or null when the cookie is
+     * not a usable credential. Runs blocking network I/O.
+     *
+     * The login screen needs this because Deezer hands out an `arl` cookie to anonymous visitors too:
+     * without verifying, a user who closed the page before signing in would be told they were signed
+     * in and then get silence on every track.
+     */
+    fun verifyArl(arl: String): AccountInfo? =
+        runCatching {
+            val json = gateway(arl.trim(), apiToken = "", method = "deezer.getUserData", payload = null)
+            val user = json.optJSONObject("results")?.optJSONObject("USER") ?: return@runCatching null
+            // An anonymous or expired ARL still returns HTTP 200, just with USER_ID 0.
+            if (user.optLong("USER_ID", 0L) == 0L) return@runCatching null
+            val options = user.optJSONObject("OPTIONS")
+            val name =
+                sequenceOf(
+                    user.optString("BLOG_NAME"),
+                    user.optString("FIRSTNAME"),
+                    user.optString("EMAIL"),
+                ).firstOrNull { it.isNotBlank() } ?: "Deezer"
+            AccountInfo(
+                name = name,
+                lossless =
+                    options?.optBoolean("web_lossless", false) == true ||
+                        options?.optBoolean("mobile_lossless", false) == true,
+            )
+        }.onFailure { Timber.tag(TAG).w(it, "ARL verification failed") }
+            .getOrNull()
+
     /** An authenticated gateway session derived from one pooled ARL. */
     private data class Session(
         val arl: String,
@@ -131,8 +212,8 @@ object DeezerAudioProvider {
         listOf(mediaId, title.lowercase(), artists.joinToString(",").lowercase(), album.orEmpty().lowercase())
             .joinToString("|")
 
-    /** True when at least one pooled Deezer account is available. */
-    fun hasBackends(): Boolean = PoolAccountManager.deezerAccounts().isNotEmpty()
+    /** True when at least one Deezer account is available, manual or pooled. */
+    fun hasBackends(): Boolean = accounts().isNotEmpty()
 
     /** Drops the cached stream for [query] at [format], forcing the next resolve to refetch. */
     fun invalidate(
@@ -159,9 +240,9 @@ object DeezerAudioProvider {
         query: Query,
         format: String,
     ): Resolved? {
-        val accounts = PoolAccountManager.deezerAccounts()
+        val accounts = accounts()
         if (accounts.isEmpty()) {
-            Timber.tag(TAG).d("resolve skipped: no pooled accounts")
+            Timber.tag(TAG).d("resolve skipped: no manual or pooled accounts")
             return null
         }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/deezer/DeezerAudioProvider.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/deezer/DeezerAudioProvider.kt
@@ -54,6 +54,13 @@ object DeezerAudioProvider {
     private const val MIME_FLAC = "audio/flac"
     private const val MIME_MPEG = "audio/mpeg"
 
+    const val FORMAT_FLAC = "FLAC"
+    const val FORMAT_MP3_320 = "MP3_320"
+    const val FORMAT_MP3_128 = "MP3_128"
+
+    /** Deezer's tiers, best first. Ordering matters: a resolve offers the requested tier and all below. */
+    private val FORMAT_TIERS = listOf(FORMAT_FLAC, FORMAT_MP3_320, FORMAT_MP3_128)
+
     private val client =
         OkHttpClient
             .Builder()
@@ -127,25 +134,30 @@ object DeezerAudioProvider {
     /** True when at least one pooled Deezer account is available. */
     fun hasBackends(): Boolean = PoolAccountManager.deezerAccounts().isNotEmpty()
 
-    /** Drops the cached stream for [query] at [lossless], forcing the next resolve to refetch. */
+    /** Drops the cached stream for [query] at [format], forcing the next resolve to refetch. */
     fun invalidate(
         query: Query,
-        lossless: Boolean,
+        format: String,
     ) {
-        val key = query.cacheKey() + ":" + lossless
+        val key = query.cacheKey() + ":" + format
         streamCache.remove(key)
         failureCache.remove(key)
     }
 
     /**
-     * Resolves a playable stream for [query], preferring FLAC when [lossless] is set.
+     * Resolves a playable stream for [query] at [format] (`FLAC`, `MP3_320` or `MP3_128` — see
+     * `DeezerAudioQuality.toFormatName()`), degrading to the next tier down when the account's plan
+     * does not cover the requested one.
+     *
+     * Takes the format as a plain string rather than the preference enum so this stays independent of
+     * the settings layer, matching how `QobuzAudioProvider` takes a bare `formatId`.
      *
      * Returns null when no pooled account can serve the track. The returned [Resolved] carries a
      * `deezer://` URI rather than the CDN URL, because the bytes still need decrypting.
      */
     fun resolve(
         query: Query,
-        lossless: Boolean,
+        format: String,
     ): Resolved? {
         val accounts = PoolAccountManager.deezerAccounts()
         if (accounts.isEmpty()) {
@@ -154,7 +166,7 @@ object DeezerAudioProvider {
         }
 
         val now = System.currentTimeMillis()
-        val cacheKey = query.cacheKey() + ":" + lossless
+        val cacheKey = query.cacheKey() + ":" + format
         streamCache[cacheKey]?.let { cached ->
             if (cached.expiresAt > now) return cached.stream
             streamCache.remove(cacheKey)
@@ -164,16 +176,16 @@ object DeezerAudioProvider {
             failureCache.remove(cacheKey)
         }
 
-        // A lossless request is only satisfiable by an account that actually has the entitlement, so
-        // those are tried first; a lossy request can use any account.
+        // Accounts with a paid plan come first so a FLAC request has the best chance of being served
+        // at full quality. An account whose plan cannot cover the requested tier is NOT skipped: it
+        // degrades to the highest tier it does have, so a pool of free accounts still plays the track
+        // instead of the whole source going silent.
         val ordered = accounts.sortedByDescending { it.premium }
         for (account in ordered) {
             val session =
                 runCatching { session(account) }
                     .onFailure { Timber.tag(TAG).w(it, "session failed for pooled account") }
                     .getOrNull() ?: continue
-
-            if (lossless && !session.lossless) continue
 
             val match =
                 runCatching { matchTrack(session, query) }
@@ -182,7 +194,7 @@ object DeezerAudioProvider {
             val trackId = match.id
 
             val media =
-                runCatching { requestUrl(session, trackId, lossless) }
+                runCatching { requestUrl(session, trackId, format) }
                     .onFailure { Timber.tag(TAG).w(it, "get_url failed for track %s", trackId) }
                     .getOrNull()
             if (media == null) {
@@ -199,7 +211,15 @@ object DeezerAudioProvider {
                     // MP3 is mpeg-layer-3, not AAC; naming it "mp4a" would mislead the extractor.
                     codecs = if (media.flac) "flac" else "mp3",
                     contentLength = media.contentLength,
-                    label = if (media.flac) "Deezer FLAC" else "Deezer MP3",
+                    // Report the tier actually served, not the one requested, so the player does not
+                    // claim FLAC for a track that degraded to MP3.
+                    label =
+                        when (media.format.uppercase()) {
+                            FORMAT_FLAC -> "Deezer FLAC"
+                            FORMAT_MP3_320 -> "Deezer MP3 320"
+                            FORMAT_MP3_128 -> "Deezer MP3 128"
+                            else -> "Deezer"
+                        },
                     matchedTitle = match.title,
                     matchedArtist = match.artists.firstOrNull(),
                     matchedAlbum = match.album,
@@ -348,6 +368,8 @@ object DeezerAudioProvider {
     private class Media(
         val url: String,
         val flac: Boolean,
+        /** The tier the gateway served, which may be lower than the one requested. */
+        val format: String,
         val contentLength: Long?,
     )
 
@@ -360,7 +382,7 @@ object DeezerAudioProvider {
     private fun requestUrl(
         session: Session,
         trackId: String,
-        lossless: Boolean,
+        format: String,
     ): Media? {
         val trackJson =
             gateway(
@@ -372,17 +394,15 @@ object DeezerAudioProvider {
         val trackToken = trackJson.optJSONObject("results")?.optString("TRACK_TOKEN").orEmpty()
         if (trackToken.isBlank()) return null
 
-        // Ask for FLAC first when allowed, then fall back to 320kbps MP3 within the same request so a
-        // track without a lossless master still plays instead of failing the whole resolve.
-        val formats =
-            buildList {
-                if (lossless && session.lossless) add("FLAC")
-                add("MP3_320")
-                add("MP3_128")
-            }
+        // Offer the requested tier and everything below it in one request, so a track with no lossless
+        // master (or an account without the entitlement) still plays at the best available quality
+        // instead of failing the resolve. FLAC is dropped when the plan does not cover it, otherwise
+        // the gateway would answer with an empty media list.
+        val requested = if (format == FORMAT_FLAC && !session.lossless) FORMAT_MP3_320 else format
+        val formats = FORMAT_TIERS.dropWhile { it != requested }.ifEmpty { listOf(FORMAT_MP3_320, FORMAT_MP3_128) }
         val formatArray = JSONArray()
-        formats.forEach { format ->
-            formatArray.put(JSONObject().put("cipher", "BF_CBC_STRIPE").put("format", format))
+        formats.forEach { tier ->
+            formatArray.put(JSONObject().put("cipher", "BF_CBC_STRIPE").put("format", tier))
         }
         val mediaArray =
             JSONArray().put(
@@ -415,20 +435,21 @@ object DeezerAudioProvider {
         val media = first.optJSONArray("media")?.optJSONObject(0) ?: return null
         val source = media.optJSONArray("sources")?.optJSONObject(0) ?: return null
         val url = source.optString("url").takeIf { it.isNotBlank() } ?: return null
-        val format = media.optString("format")
-        val flac = format.equals("FLAC", ignoreCase = true)
+        // The tier the gateway actually served, which may be lower than the one requested.
+        val servedFormat = media.optString("format")
+        val flac = servedFormat.equals(FORMAT_FLAC, ignoreCase = true)
 
         // song.getData carries a per-format size (FILESIZE_FLAC, FILESIZE_MP3_320, ...). The encrypted
         // stream is byte-for-byte the same length as the decrypted one because BF_CBC_STRIPE adds no
         // padding, so this size is valid for the decrypted output and saves a HEAD probe. Null is fine:
         // DirectStream treats an unknown length as "ask the CDN".
-        val sizeField = if (flac) "FILESIZE_FLAC" else "FILESIZE_${format.uppercase()}"
+        val sizeField = "FILESIZE_${servedFormat.uppercase()}"
         val results = trackJson.optJSONObject("results")
         val contentLength =
             results?.optString(sizeField)?.toLongOrNull()?.takeIf { it > 0L }
                 ?: results?.optString("FILESIZE")?.toLongOrNull()?.takeIf { it > 0L }
 
-        return Media(url = url, flac = flac, contentLength = contentLength)
+        return Media(url = url, flac = flac, format = servedFormat, contentLength = contentLength)
     }
 
     private val JSON_MEDIA = "application/json; charset=utf-8".toMediaTypeOrNull()

--- a/app/src/main/kotlin/moe/rukamori/archivetune/deezer/DeezerAudioProvider.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/deezer/DeezerAudioProvider.kt
@@ -1,0 +1,435 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.deezer
+
+import moe.rukamori.archivetune.audiosource.TrackMatching
+import moe.rukamori.archivetune.utils.PoolAccountManager
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONArray
+import org.json.JSONObject
+import timber.log.Timber
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+
+/**
+ * Resolves playable Deezer streams for a track, mirroring the shape of
+ * [moe.rukamori.archivetune.qobuz.QobuzAudioProvider] so the two are interchangeable at the call
+ * site.
+ *
+ * Deezer differs from Tidal/Qobuz in two ways that shape this file:
+ *  - There is no community restream tier. Every resolve runs against Deezer's own gateway using a
+ *    pooled `arl` cookie, so accounts are the only backend and [PoolAccountManager] is the only
+ *    source of them.
+ *  - The CDN never returns plain audio. Resolved URLs are wrapped in a `deezer://` URI so
+ *    [DeezerDecryptingDataSource] can undo the Blowfish chunk encryption in flight; handing the raw
+ *    CDN URL to Media3 would play noise.
+ *
+ * All calls run blocking network I/O and must not be made from the main thread.
+ */
+object DeezerAudioProvider {
+    private const val TAG = "Deezer"
+    private const val SEARCH_LIMIT = 10
+    private const val SEARCH_CACHE_MS = 10 * 60 * 1000L
+    private const val STREAM_CACHE_MS = 30 * 60 * 1000L
+    private const val FAILURE_CACHE_MS = 10 * 60 * 1000L
+
+    /** Deezer expires stream URLs well before this, but sessions are reused across resolves. */
+    private const val SESSION_TTL_MS = 45 * 60 * 1000L
+
+    private const val GATEWAY = "https://www.deezer.com/ajax/gw-light.php"
+    private const val MEDIA_ENDPOINT = "https://media.deezer.com/v1/get_url"
+    private const val USER_AGENT =
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) " +
+            "Chrome/124.0.0.0 Safari/537.36"
+
+    private const val MIME_FLAC = "audio/flac"
+    private const val MIME_MPEG = "audio/mpeg"
+
+    private val client =
+        OkHttpClient
+            .Builder()
+            .connectTimeout(6, TimeUnit.SECONDS)
+            .readTimeout(10, TimeUnit.SECONDS)
+            .callTimeout(15, TimeUnit.SECONDS)
+            .build()
+
+    /** An authenticated gateway session derived from one pooled ARL. */
+    private data class Session(
+        val arl: String,
+        val apiToken: String,
+        val licenseToken: String,
+        val lossless: Boolean,
+        val masterSecret: String?,
+        val establishedAt: Long,
+    )
+
+    /**
+     * A resolved Deezer stream, in this provider's own shape rather than the playback layer's
+     * `DirectStream`.
+     *
+     * Keeping the provider free of playback types lets it be built and tested before Deezer is wired
+     * into the source-resolution chain; the playback layer adapts this into a `DirectStream`. The
+     * `matched*` fields are the catalog metadata of the hit that was chosen, and the playback layer
+     * needs them to re-check the pick against its own `TitleMatch` gate — a stream with no matched
+     * title is rejected there, so these are not optional extras.
+     */
+    data class Resolved(
+        val uri: String,
+        val mimeType: String,
+        val codecs: String,
+        val contentLength: Long?,
+        val label: String,
+        val matchedTitle: String,
+        val matchedArtist: String?,
+        val matchedAlbum: String?,
+        val matchedDurationMs: Long?,
+        val sampleRate: Int?,
+        val bitDepth: Int?,
+    )
+
+    private class CachedStream(
+        val stream: Resolved,
+        val expiresAt: Long,
+    )
+
+    private val sessions = ConcurrentHashMap<String, Session>()
+    private val searchCache = ConcurrentHashMap<String, Pair<TrackMatching.Candidate?, Long>>()
+    private val streamCache = ConcurrentHashMap<String, CachedStream>()
+    private val failureCache = ConcurrentHashMap<String, Long>()
+
+    /** Track id of the most recent successful resolve, used by settings screens as a health probe. */
+    @Volatile
+    var lastResolvedTrackId: String? = null
+        private set
+
+    /** Mirrors the Tidal/Qobuz query shape so callers can switch providers without reshaping input. */
+    data class Query(
+        val mediaId: String,
+        val title: String,
+        val artists: List<String>,
+        val album: String?,
+        val durationMs: Long?,
+    )
+
+    private fun Query.cacheKey(): String =
+        listOf(mediaId, title.lowercase(), artists.joinToString(",").lowercase(), album.orEmpty().lowercase())
+            .joinToString("|")
+
+    /** True when at least one pooled Deezer account is available. */
+    fun hasBackends(): Boolean = PoolAccountManager.deezerAccounts().isNotEmpty()
+
+    /** Drops the cached stream for [query] at [lossless], forcing the next resolve to refetch. */
+    fun invalidate(
+        query: Query,
+        lossless: Boolean,
+    ) {
+        val key = query.cacheKey() + ":" + lossless
+        streamCache.remove(key)
+        failureCache.remove(key)
+    }
+
+    /**
+     * Resolves a playable stream for [query], preferring FLAC when [lossless] is set.
+     *
+     * Returns null when no pooled account can serve the track. The returned [Resolved] carries a
+     * `deezer://` URI rather than the CDN URL, because the bytes still need decrypting.
+     */
+    fun resolve(
+        query: Query,
+        lossless: Boolean,
+    ): Resolved? {
+        val accounts = PoolAccountManager.deezerAccounts()
+        if (accounts.isEmpty()) {
+            Timber.tag(TAG).d("resolve skipped: no pooled accounts")
+            return null
+        }
+
+        val now = System.currentTimeMillis()
+        val cacheKey = query.cacheKey() + ":" + lossless
+        streamCache[cacheKey]?.let { cached ->
+            if (cached.expiresAt > now) return cached.stream
+            streamCache.remove(cacheKey)
+        }
+        failureCache[cacheKey]?.let { failedUntil ->
+            if (failedUntil > now) return null
+            failureCache.remove(cacheKey)
+        }
+
+        // A lossless request is only satisfiable by an account that actually has the entitlement, so
+        // those are tried first; a lossy request can use any account.
+        val ordered = accounts.sortedByDescending { it.premium }
+        for (account in ordered) {
+            val session =
+                runCatching { session(account) }
+                    .onFailure { Timber.tag(TAG).w(it, "session failed for pooled account") }
+                    .getOrNull() ?: continue
+
+            if (lossless && !session.lossless) continue
+
+            val match =
+                runCatching { matchTrack(session, query) }
+                    .onFailure { Timber.tag(TAG).w(it, "search failed") }
+                    .getOrNull() ?: continue
+            val trackId = match.id
+
+            val media =
+                runCatching { requestUrl(session, trackId, lossless) }
+                    .onFailure { Timber.tag(TAG).w(it, "get_url failed for track %s", trackId) }
+                    .getOrNull()
+            if (media == null) {
+                // The session may have gone stale mid-resolve; drop it so the next attempt re-auths.
+                sessions.remove(account.arl)
+                continue
+            }
+
+            lastResolvedTrackId = trackId
+            val stream =
+                Resolved(
+                    uri = DeezerCrypto.buildUri(media.url, trackId, session.masterSecret),
+                    mimeType = if (media.flac) MIME_FLAC else MIME_MPEG,
+                    // MP3 is mpeg-layer-3, not AAC; naming it "mp4a" would mislead the extractor.
+                    codecs = if (media.flac) "flac" else "mp3",
+                    contentLength = media.contentLength,
+                    label = if (media.flac) "Deezer FLAC" else "Deezer MP3",
+                    matchedTitle = match.title,
+                    matchedArtist = match.artists.firstOrNull(),
+                    matchedAlbum = match.album,
+                    matchedDurationMs = match.durationMs,
+                    // Deezer's gateway does not report either, and FLAC here is always CD-quality, so
+                    // report the known 16/44.1 for FLAC and leave MP3 to the consumer's tier heuristic.
+                    sampleRate = if (media.flac) 44_100 else null,
+                    bitDepth = if (media.flac) 16 else null,
+                )
+            streamCache[cacheKey] = CachedStream(stream, System.currentTimeMillis() + STREAM_CACHE_MS)
+            return stream
+        }
+
+        failureCache[cacheKey] = System.currentTimeMillis() + FAILURE_CACHE_MS
+        return null
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Session
+    // ---------------------------------------------------------------------------------------------
+
+    /** Returns a live session for [account], reusing a cached one until it ages out. */
+    private fun session(account: PoolAccountManager.DeezerPoolAccount): Session {
+        val now = System.currentTimeMillis()
+        sessions[account.arl]?.let { if (now - it.establishedAt < SESSION_TTL_MS) return it }
+
+        val json = gateway(account.arl, apiToken = "", method = "deezer.getUserData", payload = null)
+        val results = json.optJSONObject("results")
+        val user = requireNotNull(results?.optJSONObject("USER")) { "no USER in session payload" }
+        // An invalid or expired ARL still returns HTTP 200 with USER_ID 0, so this is the real check.
+        require(user.optLong("USER_ID", 0L) != 0L) { "ARL rejected by gateway" }
+
+        val options = requireNotNull(user.optJSONObject("OPTIONS")) { "no OPTIONS in session payload" }
+        val licenseToken = options.optString("license_token")
+        require(licenseToken.isNotBlank()) { "no license_token in session" }
+
+        val apiToken = results?.optString("checkForm").orEmpty()
+        require(apiToken.isNotBlank()) { "no api token in session" }
+
+        val session =
+            Session(
+                arl = account.arl,
+                apiToken = apiToken,
+                licenseToken = licenseToken,
+                // Entitlement lives in flat OPTIONS booleans. Check both the web and mobile flags: a
+                // plan can carry lossless on one surface only, and either is enough for us to ask for
+                // FLAC. The pool's own `premium` hint only orders attempts; this is the real gate.
+                lossless =
+                    options.optBoolean("web_lossless", false) ||
+                        options.optBoolean("mobile_lossless", false),
+                masterSecret = account.masterSecret,
+                establishedAt = now,
+            )
+        sessions[account.arl] = session
+        return session
+    }
+
+    private fun gateway(
+        arl: String,
+        apiToken: String,
+        method: String,
+        payload: JSONObject?,
+    ): JSONObject {
+        val url =
+            GATEWAY
+                .toHttpUrl()
+                .newBuilder()
+                .addQueryParameter("method", method)
+                .addQueryParameter("input", "3")
+                .addQueryParameter("api_version", "1.0")
+                .addQueryParameter("api_token", apiToken)
+                .build()
+        val body = (payload ?: JSONObject()).toString().toRequestBody(JSON_MEDIA)
+        val request =
+            Request
+                .Builder()
+                .url(url)
+                .header("User-Agent", USER_AGENT)
+                .header("Cookie", "arl=$arl")
+                .post(body)
+                .build()
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) throw java.io.IOException("gateway HTTP ${response.code}")
+            return JSONObject(response.body?.string().orEmpty())
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Search
+    // ---------------------------------------------------------------------------------------------
+
+    /** Finds the Deezer track id that best matches [query], or null when nothing scores high enough. */
+    private fun matchTrack(
+        session: Session,
+        query: Query,
+    ): TrackMatching.Candidate? {
+        val key = query.cacheKey()
+        val now = System.currentTimeMillis()
+        searchCache[key]?.let { (candidate, expiresAt) ->
+            if (expiresAt > now) return candidate
+            searchCache.remove(key)
+        }
+
+        val terms = listOf(query.title) + query.artists.take(1)
+        val payload =
+            JSONObject()
+                .put("query", terms.joinToString(" ").trim())
+                .put("start", 0)
+                .put("nb", SEARCH_LIMIT)
+        val json = gateway(session.arl, session.apiToken, "search.music", payload)
+        val data = json.optJSONObject("results")?.optJSONArray("data") ?: JSONArray()
+
+        val candidates =
+            (0 until data.length()).mapNotNull { i ->
+                val obj = data.optJSONObject(i) ?: return@mapNotNull null
+                val id = obj.optString("SNG_ID").takeIf { it.isNotBlank() } ?: return@mapNotNull null
+                TrackMatching.Candidate(
+                    id = id,
+                    title = obj.optString("SNG_TITLE"),
+                    artists = listOfNotNull(obj.optString("ART_NAME").takeIf { it.isNotBlank() }),
+                    album = obj.optString("ALB_TITLE").takeIf { it.isNotBlank() },
+                    // Deezer reports duration in whole seconds.
+                    durationMs = obj.optLong("DURATION", 0L).takeIf { it > 0L }?.times(1000L),
+                )
+            }
+
+        val best =
+            TrackMatching.best(
+                target =
+                    TrackMatching.Target(
+                        title = query.title,
+                        artists = query.artists,
+                        album = query.album,
+                        durationMs = query.durationMs,
+                    ),
+                candidates = candidates,
+            )
+        searchCache[key] = best to (now + SEARCH_CACHE_MS)
+        return best
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Stream URL
+    // ---------------------------------------------------------------------------------------------
+
+    private class Media(
+        val url: String,
+        val flac: Boolean,
+        val contentLength: Long?,
+    )
+
+    /**
+     * Exchanges a track id for a CDN URL via the media endpoint.
+     *
+     * Deezer needs the track's per-format `TRACK_TOKEN` (not the numeric id) here, so this makes a
+     * second gateway call to fetch it before asking for the URL.
+     */
+    private fun requestUrl(
+        session: Session,
+        trackId: String,
+        lossless: Boolean,
+    ): Media? {
+        val trackJson =
+            gateway(
+                session.arl,
+                session.apiToken,
+                "song.getData",
+                JSONObject().put("sng_id", trackId),
+            )
+        val trackToken = trackJson.optJSONObject("results")?.optString("TRACK_TOKEN").orEmpty()
+        if (trackToken.isBlank()) return null
+
+        // Ask for FLAC first when allowed, then fall back to 320kbps MP3 within the same request so a
+        // track without a lossless master still plays instead of failing the whole resolve.
+        val formats =
+            buildList {
+                if (lossless && session.lossless) add("FLAC")
+                add("MP3_320")
+                add("MP3_128")
+            }
+        val formatArray = JSONArray()
+        formats.forEach { format ->
+            formatArray.put(JSONObject().put("cipher", "BF_CBC_STRIPE").put("format", format))
+        }
+        val mediaArray =
+            JSONArray().put(
+                JSONObject()
+                    .put("type", "FULL")
+                    .put("formats", formatArray),
+            )
+        val cipherPayload =
+            JSONObject()
+                .put("license_token", session.licenseToken)
+                .put("media", mediaArray)
+                .put("track_tokens", JSONArray().put(trackToken))
+
+        val request =
+            Request
+                .Builder()
+                .url(MEDIA_ENDPOINT)
+                .header("User-Agent", USER_AGENT)
+                .header("Cookie", "arl=${session.arl}")
+                .post(cipherPayload.toString().toRequestBody(JSON_MEDIA))
+                .build()
+
+        val json =
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) throw java.io.IOException("get_url HTTP ${response.code}")
+                JSONObject(response.body?.string().orEmpty())
+            }
+
+        val first = json.optJSONArray("data")?.optJSONObject(0) ?: return null
+        val media = first.optJSONArray("media")?.optJSONObject(0) ?: return null
+        val source = media.optJSONArray("sources")?.optJSONObject(0) ?: return null
+        val url = source.optString("url").takeIf { it.isNotBlank() } ?: return null
+        val format = media.optString("format")
+        val flac = format.equals("FLAC", ignoreCase = true)
+
+        // song.getData carries a per-format size (FILESIZE_FLAC, FILESIZE_MP3_320, ...). The encrypted
+        // stream is byte-for-byte the same length as the decrypted one because BF_CBC_STRIPE adds no
+        // padding, so this size is valid for the decrypted output and saves a HEAD probe. Null is fine:
+        // DirectStream treats an unknown length as "ask the CDN".
+        val sizeField = if (flac) "FILESIZE_FLAC" else "FILESIZE_${format.uppercase()}"
+        val results = trackJson.optJSONObject("results")
+        val contentLength =
+            results?.optString(sizeField)?.toLongOrNull()?.takeIf { it > 0L }
+                ?: results?.optString("FILESIZE")?.toLongOrNull()?.takeIf { it > 0L }
+
+        return Media(url = url, flac = flac, contentLength = contentLength)
+    }
+
+    private val JSON_MEDIA = "application/json; charset=utf-8".toMediaTypeOrNull()
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/deezer/DeezerCrypto.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/deezer/DeezerCrypto.kt
@@ -1,0 +1,145 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ */
+
+package moe.rukamori.archivetune.deezer
+
+import android.net.Uri
+import androidx.core.net.toUri
+import java.security.MessageDigest
+import javax.crypto.Cipher
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Blowfish stream layout used by Deezer's CDN, plus the `deezer://` URI wrapper that carries a
+ * resolved stream from [DeezerAudioProvider] to [DeezerDecryptingDataSource].
+ *
+ * Deezer does not serve plain audio: the CDN returns the file in fixed 2048-byte chunks where every
+ * third chunk is Blowfish-CBC encrypted under a key derived from the track id, and the rest are
+ * plaintext. So there is no URL we could hand to Media3 directly — the bytes have to be transformed
+ * in flight, which is why a custom DataSource exists at all.
+ *
+ * The chunk layout is what makes seeking survivable. Each encrypted chunk restarts from the same
+ * fixed IV instead of chaining into the next one, so any chunk can be decrypted without having read
+ * the ones before it. That is the property [DeezerDecryptingDataSource] relies on to seek: it snaps
+ * a requested byte offset down to a chunk boundary rather than having to stream from zero.
+ */
+internal object DeezerCrypto {
+    /** Deezer's CDN chunk size. Encryption applies per whole chunk, so this is also the seek grain. */
+    const val CHUNK_SIZE = 2048
+
+    /** Only every third chunk is encrypted; the other two are stored as plaintext. */
+    const val ENCRYPTED_CHUNK_STRIDE = 3
+
+    /** Scheme for the internal URI that wraps a resolved Deezer stream. */
+    const val SCHEME = "deezer"
+
+    private const val PARAM_URL = "u"
+    private const val PARAM_KEY = "k"
+    private const val PARAM_SALT = "s"
+
+    /**
+     * Fixed key-derivation salt for the per-track Blowfish key. Deezer reuses one constant for every
+     * track and derives the actual key from the track id, so this alone unlocks nothing — resolving a
+     * playable CDN URL still requires an authenticated account (see [DeezerAudioProvider]).
+     */
+    const val DEFAULT_KEY_SALT = "g4el58wc0zvf9na1"
+
+    /** Deezer restarts every encrypted chunk from this same IV, which is what makes chunks seekable. */
+    private val CHUNK_IV = byteArrayOf(0, 1, 2, 3, 4, 5, 6, 7)
+
+    /**
+     * Derives the 16-byte Blowfish key for [trackId] by XOR-folding the two halves of the track id's
+     * MD5 against [salt], which defaults to [DEFAULT_KEY_SALT].
+     *
+     * Note this consumes the MD5 as lowercase hex *text*, not as raw digest bytes — the bytes of the
+     * hex characters are what get XORed. Using the raw digest yields a wrong key that still decrypts
+     * without error, producing plausible-looking noise instead of a failure, so this stays explicit.
+     */
+    fun deriveKey(
+        trackId: String,
+        salt: String = DEFAULT_KEY_SALT,
+    ): ByteArray {
+        // A short override would index out of bounds below, and a wrong-length salt cannot be the
+        // real one anyway, so fall back rather than crash on a bad pool payload.
+        val effective = if (salt.length >= 16) salt else DEFAULT_KEY_SALT
+        val md5Hex =
+            MessageDigest
+                .getInstance("MD5")
+                .digest(trackId.toByteArray(Charsets.UTF_8))
+                .joinToString("") { "%02x".format(it) }
+        return ByteArray(16) { i ->
+            (md5Hex[i].code xor md5Hex[i + 16].code xor effective[i].code).toByte()
+        }
+    }
+
+    /** True when the chunk at absolute [chunkIndex] is encrypted rather than stored plaintext. */
+    fun isEncryptedChunk(chunkIndex: Long): Boolean = chunkIndex % ENCRYPTED_CHUNK_STRIDE == 0L
+
+    /**
+     * Decrypts one whole chunk in place, in-place over the first [length] bytes of [chunk].
+     *
+     * [length] must be a multiple of the Blowfish 8-byte block size; callers only ever pass a
+     * complete [CHUNK_SIZE] chunk, because a trailing short chunk is never encrypted in the first
+     * place and must be passed through untouched.
+     */
+    fun decryptChunk(
+        chunk: ByteArray,
+        length: Int,
+        key: ByteArray,
+    ) {
+        if (length < 8) return
+        // Any remainder past the last whole 8-byte block is stored as-is and must not be fed to the
+        // cipher, which would throw on a partial block.
+        val decryptable = length - (length % 8)
+        val cipher = Cipher.getInstance("Blowfish/CBC/NoPadding")
+        cipher.init(Cipher.DECRYPT_MODE, SecretKeySpec(key, "Blowfish"), IvParameterSpec(CHUNK_IV))
+        cipher.doFinal(chunk, 0, decryptable, chunk, 0)
+    }
+
+    /**
+     * Wraps a real CDN [url] and its [trackId] into a `deezer://` URI.
+     *
+     * The scheme exists so the existing scheme-routing DataSources in `MusicService` and
+     * `DownloadUtil` can dispatch Deezer bytes to the decrypting source the same way they already
+     * dispatch `telegram://`. The track id rides along because the decryption key derives from it and
+     * the DataSource has no other way to recover it.
+     */
+    fun buildUri(
+        url: String,
+        trackId: String,
+        salt: String? = null,
+    ): String =
+        Uri
+            .Builder()
+            .scheme(SCHEME)
+            .authority("stream")
+            .appendQueryParameter(PARAM_URL, url)
+            .appendQueryParameter(PARAM_KEY, trackId)
+            .apply {
+                // Only carried when a pool account overrode it, so ordinary URIs stay short.
+                if (!salt.isNullOrBlank() && salt != DEFAULT_KEY_SALT) {
+                    appendQueryParameter(PARAM_SALT, salt)
+                }
+            }.build()
+            .toString()
+
+    /** A resolved Deezer stream recovered from a [buildUri] URI. */
+    data class StreamRef(
+        val url: Uri,
+        val trackId: String,
+        val salt: String,
+    )
+
+    /** The CDN URL, track id and key salt carried by a [buildUri] URI, or null when [uri] is not one. */
+    fun parseUri(uri: Uri): StreamRef? {
+        if (!uri.scheme.equals(SCHEME, ignoreCase = true)) return null
+        val url = uri.getQueryParameter(PARAM_URL)?.takeIf { it.isNotBlank() } ?: return null
+        val trackId = uri.getQueryParameter(PARAM_KEY)?.takeIf { it.isNotBlank() } ?: return null
+        val salt = uri.getQueryParameter(PARAM_SALT)?.takeIf { it.isNotBlank() } ?: DEFAULT_KEY_SALT
+        return StreamRef(url.toUri(), trackId, salt)
+    }
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/deezer/DeezerDecryptingDataSource.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/deezer/DeezerDecryptingDataSource.kt
@@ -1,0 +1,218 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ *
+ * Media3 DataSource that streams a Deezer CDN file and Blowfish-decrypts it in flight, so the
+ * extractor above it sees an ordinary FLAC/MP3 byte stream.
+ *
+ * This is deliberately a DataSource rather than a standalone downloader. Downloads in this app run
+ * through Media3's DownloadManager over the same DataSource factory as playback, so implementing
+ * Deezer here means downloading, caching, tag embedding and codec reporting all keep working with no
+ * Deezer-specific code in those paths. An external HTTP download loop is what produced corrupted
+ * files and unreadable tags in earlier attempts at Deezer support elsewhere.
+ */
+
+package moe.rukamori.archivetune.deezer
+
+import android.net.Uri
+import androidx.media3.common.C
+import androidx.media3.datasource.BaseDataSource
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DataSpec
+import timber.log.Timber
+import java.io.IOException
+import kotlin.math.min
+
+/**
+ * Wraps [upstreamFactory] (an HTTP source) and decrypts Deezer's chunked Blowfish stream.
+ *
+ * Reads are served out of a one-chunk buffer: a whole 2048-byte chunk is pulled from upstream,
+ * decrypted if its absolute index says it is encrypted, and then drained to the caller across as many
+ * [read] calls as it takes. Buffering a whole chunk is required rather than an optimisation — a chunk
+ * cannot be decrypted until all of it has arrived.
+ */
+internal class DeezerDecryptingDataSource(
+    private val upstreamFactory: DataSource.Factory,
+) : BaseDataSource(true) {
+    private var upstream: DataSource? = null
+    private var currentUri: Uri? = null
+    private var key: ByteArray? = null
+
+    private val chunk = ByteArray(DeezerCrypto.CHUNK_SIZE)
+
+    /** Valid decrypted bytes currently held in [chunk], and how far the caller has drained them. */
+    private var chunkLength = 0
+    private var chunkOffset = 0
+
+    /** Absolute index of the next chunk to fetch, which decides whether it is encrypted. */
+    private var nextChunkIndex = 0L
+
+    /** Bytes still owed to the caller, or [C.LENGTH_UNSET] when the total length is unknown. */
+    private var bytesRemaining = C.LENGTH_UNSET.toLong()
+
+    private var opened = false
+
+    override fun open(dataSpec: DataSpec): Long {
+        val ref =
+            DeezerCrypto.parseUri(dataSpec.uri)
+                ?: throw IOException("Not a Deezer stream URI: ${dataSpec.uri}")
+        val realUri = ref.url
+
+        key = DeezerCrypto.deriveKey(ref.trackId, ref.salt)
+        currentUri = dataSpec.uri
+
+        // Snap the requested offset down to a chunk boundary. Encrypted chunks are only decryptable
+        // as whole chunks, so a seek landing mid-chunk has to re-fetch from that chunk's start and
+        // throw away the bytes before the target; without this, seeks decode garbage.
+        val requestedPosition = dataSpec.position
+        val alignedPosition = requestedPosition - (requestedPosition % DeezerCrypto.CHUNK_SIZE)
+        val discardCount = (requestedPosition - alignedPosition).toInt()
+        nextChunkIndex = alignedPosition / DeezerCrypto.CHUNK_SIZE
+
+        // Ask upstream for the discarded prefix too, otherwise a bounded request would come up short
+        // by exactly discardCount bytes at the end of the range.
+        val upstreamLength =
+            if (dataSpec.length == C.LENGTH_UNSET.toLong()) {
+                C.LENGTH_UNSET.toLong()
+            } else {
+                dataSpec.length + discardCount
+            }
+
+        // Deliberately not forwarding our transfer listeners to the upstream source: this class already
+        // reports every byte it hands out via bytesTransferred, and registering the same listeners
+        // downstream would count each byte twice in the bandwidth meter.
+        val source = upstreamFactory.createDataSource()
+        upstream = source
+
+        val upstreamLengthReported =
+            source.open(
+                dataSpec
+                    .buildUpon()
+                    .setUri(realUri)
+                    .setPosition(alignedPosition)
+                    .setLength(upstreamLength)
+                    .build(),
+            )
+
+        bytesRemaining =
+            when {
+                dataSpec.length != C.LENGTH_UNSET.toLong() -> dataSpec.length
+                upstreamLengthReported == C.LENGTH_UNSET.toLong() -> C.LENGTH_UNSET.toLong()
+                // Report the length the caller sees, which excludes the prefix we are about to drop.
+                else -> (upstreamLengthReported - discardCount).coerceAtLeast(0L)
+            }
+
+        opened = true
+        transferStarted(dataSpec)
+
+        // Drop the pre-seek remainder of the first chunk before returning, so the very first read()
+        // already starts at the byte the caller asked for.
+        if (discardCount > 0) discardFully(discardCount)
+
+        return bytesRemaining
+    }
+
+    override fun read(
+        buffer: ByteArray,
+        offset: Int,
+        length: Int,
+    ): Int {
+        if (length == 0) return 0
+        if (bytesRemaining == 0L) return C.RESULT_END_OF_INPUT
+
+        if (chunkOffset >= chunkLength && !fillChunk()) return C.RESULT_END_OF_INPUT
+
+        var available = chunkLength - chunkOffset
+        if (bytesRemaining != C.LENGTH_UNSET.toLong()) {
+            available = min(available.toLong(), bytesRemaining).toInt()
+        }
+        val toCopy = min(length, available)
+        if (toCopy == 0) return C.RESULT_END_OF_INPUT
+
+        chunk.copyInto(buffer, offset, chunkOffset, chunkOffset + toCopy)
+        chunkOffset += toCopy
+        if (bytesRemaining != C.LENGTH_UNSET.toLong()) bytesRemaining -= toCopy
+        bytesTransferred(toCopy)
+        return toCopy
+    }
+
+    /**
+     * Pulls the next whole chunk from upstream and decrypts it when required. Returns false at
+     * end of stream.
+     */
+    private fun fillChunk(): Boolean {
+        val source = upstream ?: return false
+        var filled = 0
+        // Loop because a single upstream read is free to return fewer bytes than asked, and a chunk
+        // that is short only because of a partial read must not be mistaken for the final chunk.
+        while (filled < DeezerCrypto.CHUNK_SIZE) {
+            val read = source.read(chunk, filled, DeezerCrypto.CHUNK_SIZE - filled)
+            if (read == C.RESULT_END_OF_INPUT) break
+            filled += read
+        }
+        if (filled == 0) return false
+
+        // A trailing partial chunk is stored plaintext, so only decrypt a chunk that came back whole.
+        if (filled == DeezerCrypto.CHUNK_SIZE && DeezerCrypto.isEncryptedChunk(nextChunkIndex)) {
+            val chunkKey = key ?: return false
+            try {
+                DeezerCrypto.decryptChunk(chunk, filled, chunkKey)
+            } catch (e: Exception) {
+                // Surface as an IOException so the player treats it as a source failure and can fall
+                // through to the next audio source, rather than crashing on a crypto exception.
+                throw IOException("Deezer chunk decryption failed at index $nextChunkIndex", e)
+            }
+        }
+
+        nextChunkIndex++
+        chunkLength = filled
+        chunkOffset = 0
+        return true
+    }
+
+    /** Drops exactly [count] decrypted bytes, used to honour a mid-chunk seek offset. */
+    private fun discardFully(count: Int) {
+        var left = count
+        while (left > 0) {
+            if (chunkOffset >= chunkLength && !fillChunk()) return
+            val skip = min(left, chunkLength - chunkOffset)
+            chunkOffset += skip
+            left -= skip
+        }
+    }
+
+    override fun getUri(): Uri? = currentUri
+
+    override fun getResponseHeaders(): Map<String, List<String>> = upstream?.responseHeaders ?: emptyMap()
+
+    override fun close() {
+        chunkLength = 0
+        chunkOffset = 0
+        key = null
+        currentUri = null
+        bytesRemaining = C.LENGTH_UNSET.toLong()
+        try {
+            upstream?.close()
+        } catch (e: IOException) {
+            Timber.tag(TAG).w(e, "Failed to close Deezer upstream")
+        } finally {
+            upstream = null
+            if (opened) {
+                opened = false
+                transferEnded()
+            }
+        }
+    }
+
+    class Factory(
+        private val upstreamFactory: DataSource.Factory,
+    ) : DataSource.Factory {
+        override fun createDataSource(): DataSource = DeezerDecryptingDataSource(upstreamFactory)
+    }
+
+    private companion object {
+        private const val TAG = "DeezerDataSource"
+    }
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/DownloadUtil.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/DownloadUtil.kt
@@ -38,6 +38,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import moe.rukamori.archivetune.constants.AudioQuality
 import moe.rukamori.archivetune.constants.AudioQualityKey
+import moe.rukamori.archivetune.constants.DeezerAudioQuality
+import moe.rukamori.archivetune.constants.DeezerAudioQualityKey
 import moe.rukamori.archivetune.constants.DownloadSource
 import moe.rukamori.archivetune.constants.DownloadSourceKey
 import moe.rukamori.archivetune.constants.QobuzAudioQuality
@@ -45,6 +47,10 @@ import moe.rukamori.archivetune.constants.QobuzAudioQualityKey
 import moe.rukamori.archivetune.constants.TidalAudioQuality
 import moe.rukamori.archivetune.constants.TidalAudioQualityKey
 import moe.rukamori.archivetune.constants.toFormatId
+import moe.rukamori.archivetune.constants.toFormatName
+import moe.rukamori.archivetune.deezer.DeezerAudioProvider
+import moe.rukamori.archivetune.deezer.DeezerCrypto
+import moe.rukamori.archivetune.deezer.DeezerDecryptingDataSource
 import moe.rukamori.archivetune.db.MusicDatabase
 import moe.rukamori.archivetune.db.entities.FormatEntity
 import moe.rukamori.archivetune.db.entities.SongEntity
@@ -84,6 +90,7 @@ class DownloadUtil
         private val downloadSource by enumPreference(context, DownloadSourceKey, DownloadSource.YOUTUBE_MUSIC)
         private val qobuzAudioQuality by enumPreference(context, QobuzAudioQualityKey, QobuzAudioQuality.FLAC)
         private val tidalAudioQuality by enumPreference(context, TidalAudioQualityKey, TidalAudioQuality.FLAC)
+        private val deezerAudioQuality by enumPreference(context, DeezerAudioQualityKey, DeezerAudioQuality.FLAC)
         private val downloadScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
         private val songUrlCache = ConcurrentHashMap<String, AuthScopedCacheValue>()
         private val downloadExecutor = Executors.newFixedThreadPool(DEFAULT_MAX_PARALLEL_DOWNLOADS)
@@ -203,15 +210,24 @@ class DownloadUtil
             }
 
         // Route downloads by scheme: telegram:// tracks stream through TDLib (same as playback),
-        // everything else through the YouTube-resolving factory above.
+        // deezer:// through the Blowfish-decrypting source, everything else through the
+        // YouTube-resolving factory above.
         private val telegramDataSourceFactory =
             moe.rukamori.archivetune.telegram.TelegramDataSource.Factory(context)
+
+        // Deezer downloads deliberately reuse this DownloadManager rather than running their own
+        // fetch loop, so the decrypting source sits inside the same pipeline as every other download
+        // and inherits its cache, retry and progress handling. The bytes written to disk are already
+        // decrypted, so a downloaded Deezer track plays back like any local file.
+        private val deezerDataSourceFactory =
+            DeezerDecryptingDataSource.Factory(OkHttpDataSource.Factory(mediaOkHttpClient))
 
         private val dataSourceFactory =
             DataSource.Factory {
                 DownloadSchemeRoutingDataSource(
                     youtubeFactory = youtubeDataSourceFactory,
                     telegramFactory = telegramDataSourceFactory,
+                    deezerFactory = deezerDataSourceFactory,
                 )
             }
 
@@ -349,6 +365,14 @@ class DownloadUtil
                             TidalAudioProvider.Query(mediaId, queryTitle, artists, album, null, durationMs),
                             audioQuality = tidalAudioQuality,
                         ).let { ResolvedStream(it.mediaUri, it.mimeType, it.codecs, it.contentLength) }
+                // Yields a deezer:// URI, not a CDN URL — DownloadSchemeRoutingDataSource sends it
+                // through the decrypting source so the bytes hitting disk are plain audio.
+                DownloadSource.DEEZER ->
+                    DeezerAudioProvider
+                        .resolve(
+                            DeezerAudioProvider.Query(mediaId, queryTitle, artists, album, durationMs),
+                            deezerAudioQuality.toFormatName(),
+                        )?.let { ResolvedStream(it.uri, it.mimeType, it.codecs, it.contentLength) }
                 DownloadSource.AUTO, DownloadSource.YOUTUBE_MUSIC -> null
             }
 
@@ -462,6 +486,7 @@ class DownloadUtil
         private class DownloadSchemeRoutingDataSource(
             private val youtubeFactory: DataSource.Factory,
             private val telegramFactory: DataSource.Factory,
+            private val deezerFactory: DataSource.Factory,
         ) : DataSource {
             private val transferListeners = mutableListOf<TransferListener>()
             private var delegate: DataSource? = null
@@ -473,7 +498,12 @@ class DownloadUtil
 
             override fun open(dataSpec: DataSpec): Long {
                 val scheme = dataSpec.uri.scheme?.lowercase(java.util.Locale.US)
-                val selected = if (scheme == "telegram") telegramFactory else youtubeFactory
+                val selected =
+                    when (scheme) {
+                        "telegram" -> telegramFactory
+                        DeezerCrypto.SCHEME -> deezerFactory
+                        else -> youtubeFactory
+                    }
                 val source = selected.createDataSource()
                 transferListeners.forEach(source::addTransferListener)
                 delegate = source

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -69,6 +69,7 @@ import androidx.media3.datasource.HttpDataSource
 import androidx.media3.datasource.ResolvingDataSource
 import androidx.media3.datasource.TransferListener
 import androidx.media3.datasource.cache.Cache
+import androidx.media3.datasource.cache.CacheDataSink
 import androidx.media3.datasource.cache.CacheDataSource
 import androidx.media3.datasource.cache.CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR
 import androidx.media3.datasource.cache.ContentMetadata
@@ -141,6 +142,9 @@ import moe.rukamori.archivetune.constants.AutoStartOnBluetoothKey
 import moe.rukamori.archivetune.constants.CrossfadeDurationKey
 import moe.rukamori.archivetune.constants.CrossfadeEnabledKey
 import moe.rukamori.archivetune.constants.CrossfadeGaplessKey
+import moe.rukamori.archivetune.constants.DeezerAudioQuality
+import moe.rukamori.archivetune.constants.DeezerAudioQualityKey
+import moe.rukamori.archivetune.constants.DeezerEnabledKey
 import moe.rukamori.archivetune.constants.DeviceMutePlaybackRecoveryVolumeKey
 import moe.rukamori.archivetune.constants.DiscordShowWhenPausedKey
 import moe.rukamori.archivetune.constants.DiscordTokenKey
@@ -200,6 +204,7 @@ import moe.rukamori.archivetune.constants.QobuzAudioQualityKey
 import moe.rukamori.archivetune.constants.QobuzLastProbeTrackKey
 import moe.rukamori.archivetune.constants.QobuzTokensKey
 import moe.rukamori.archivetune.constants.toFormatId
+import moe.rukamori.archivetune.constants.toFormatName
 import moe.rukamori.archivetune.qobuz.QobuzAudioProvider
 import moe.rukamori.archivetune.qobuz.QobuzToken
 import moe.rukamori.archivetune.audiosource.AudioSourceConfig
@@ -234,6 +239,9 @@ import moe.rukamori.archivetune.db.entities.LyricsEntity
 import moe.rukamori.archivetune.db.entities.RelatedSongMap
 import moe.rukamori.archivetune.db.entities.Song
 import moe.rukamori.archivetune.db.entities.SongEntity
+import moe.rukamori.archivetune.deezer.DeezerAudioProvider
+import moe.rukamori.archivetune.deezer.DeezerCrypto
+import moe.rukamori.archivetune.deezer.DeezerDecryptingDataSource
 import moe.rukamori.archivetune.di.DownloadCache
 import moe.rukamori.archivetune.di.PlayerCache
 import moe.rukamori.archivetune.extensions.SilentHandler
@@ -7493,12 +7501,26 @@ class MusicService :
         val directFactory = createResolvedUpstreamDataSourceFactory()
         // Application Context, so the factory (which outlives this Service) cannot leak it.
         val telegramFactory = TelegramDataSource.Factory(this)
+        // Deezer needs its own chain rather than cachedFactory's: that one runs the YouTube
+        // resolver over the dataSpec, which would rewrite our deezer:// URI. Decryption sits below
+        // the cache so what gets cached is already-decrypted audio, letting a replay skip both the
+        // CDN fetch and the Blowfish work.
+        val deezerFactory =
+            CacheDataSource
+                .Factory()
+                .setCache(playerCache)
+                .setUpstreamDataSourceFactory(
+                    DeezerDecryptingDataSource.Factory(OkHttpDataSource.Factory(mediaOkHttpClient)),
+                ).setCacheWriteDataSinkFactory(
+                    CacheDataSink.Factory().setCache(playerCache).setFragmentSize(C.LENGTH_UNSET.toLong()),
+                ).setFlags(CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR)
 
         return DataSource.Factory {
             SchemeRoutingDataSource(
                 cachedFactory = cachedFactory,
                 directFactory = directFactory,
                 telegramFactory = telegramFactory,
+                deezerFactory = deezerFactory,
             )
         }
     }
@@ -7587,6 +7609,7 @@ class MusicService :
                 // UI and the resolver agree on which sources are active out of the box.
                 AudioSourceType.TIDAL to dataStore.get(TidalEnabledKey, true),
                 AudioSourceType.QOBUZ to dataStore.get(QobuzEnabledKey, false),
+                AudioSourceType.DEEZER to dataStore.get(DeezerEnabledKey, false),
                 AudioSourceType.YOUTUBE to true,
             )
         // The single stored order is authoritative (top = preferred). Only sources listed BEFORE
@@ -7718,11 +7741,11 @@ class MusicService :
         }
 
         // Low Data Mode is an effective network policy, not a rewrite of the user's saved source
-        // order. On cellular/metered connections, bypass Tidal and Qobuz (including a per-song
+        // order. On cellular/metered connections, bypass every lossless source (including a per-song
         // override) and let the normal YouTube resolver select its low-data stream.
         if (lowDataModeActive) {
             tidalActiveMediaIds.remove(mediaId)
-            Timber.tag("MusicService").i("Low-data mode active; skipping Tidal/Qobuz for %s", mediaId)
+            Timber.tag("MusicService").i("Low-data mode active; skipping lossless sources for %s", mediaId)
             return null
         }
 
@@ -7745,6 +7768,7 @@ class MusicService :
                 when (source) {
                     AudioSourceType.TIDAL -> resolveTidalStream(query)
                     AudioSourceType.QOBUZ -> resolveQobuzStream(query)
+                    AudioSourceType.DEEZER -> resolveDeezerStream(query)
                     AudioSourceType.YOUTUBE -> null
                 }
             if (stream == null) {
@@ -8151,6 +8175,66 @@ class MusicService :
         }.onFailure { error ->
             Timber.tag("MusicService").w(error, "QOBUZ stream resolution failed for %s", query.mediaId)
         }.getOrNull()
+    }
+
+    /**
+     * Resolves a Deezer stream. Unlike Tidal/Qobuz there is no proxy-instance tier, so the pool is the
+     * only credential source and the whole source is a no-op until the pool has accounts.
+     */
+    private fun resolveDeezerStream(query: SourceQuery): DirectStream? {
+        val accounts = PoolAccountManager.deezerAccounts()
+        if (accounts.isEmpty()) {
+            Timber.tag("MusicService").d("Deezer skip: no pool accounts available")
+            return null
+        }
+        val quality = parseDeezerAudioQuality()
+        Timber.tag("MusicService").d(
+            "Deezer resolve start | quality=%s accounts=%d",
+            quality.name,
+            accounts.size,
+        )
+        // No setAccounts equivalent to Qobuz's setTokens: Deezer credentials come only from the pool,
+        // so the provider reads PoolAccountManager itself. The count above is logged for diagnostics.
+        return runCatching {
+            runBlocking(Dispatchers.IO) {
+                DeezerAudioProvider
+                    .resolve(
+                        query =
+                            DeezerAudioProvider.Query(
+                                mediaId = query.mediaId,
+                                title = query.title,
+                                artists = query.artists,
+                                album = query.album,
+                                durationMs = query.durationMs,
+                            ),
+                        format = quality.toFormatName(),
+                    )?.let { resolved ->
+                        // The provider deliberately returns its own type so it stays independent of the
+                        // playback layer; map it here, at the single point where the two meet.
+                        DirectStream(
+                            uri = resolved.uri,
+                            mimeType = resolved.mimeType,
+                            codecs = resolved.codecs,
+                            contentLength = resolved.contentLength,
+                            label = resolved.label,
+                            source = AudioSourceType.DEEZER,
+                            matchedTitle = resolved.matchedTitle,
+                            matchedArtist = resolved.matchedArtist,
+                            matchedAlbum = resolved.matchedAlbum,
+                            matchedDurationMs = resolved.matchedDurationMs,
+                            sampleRate = resolved.sampleRate,
+                            bitDepth = resolved.bitDepth,
+                        )
+                    }
+            }
+        }.onFailure { error ->
+            Timber.tag("MusicService").w(error, "DEEZER stream resolution failed for %s", query.mediaId)
+        }.getOrNull()
+    }
+
+    private fun parseDeezerAudioQuality(): DeezerAudioQuality {
+        val stored = dataStore.get(DeezerAudioQualityKey, DeezerAudioQuality.FLAC.name)
+        return runCatching { DeezerAudioQuality.valueOf(stored) }.getOrDefault(DeezerAudioQuality.FLAC)
     }
 
     private fun parseQobuzInstances(): List<String> =
@@ -8760,6 +8844,7 @@ class MusicService :
         private val cachedFactory: DataSource.Factory,
         private val directFactory: DataSource.Factory,
         private val telegramFactory: DataSource.Factory,
+        private val deezerFactory: DataSource.Factory,
     ) : DataSource {
         private val transferListeners = mutableListOf<TransferListener>()
         private var delegate: DataSource? = null
@@ -8776,6 +8861,9 @@ class MusicService :
                     // Telegram tracks stream through TDLib's own partial-file cache; Media3's
                     // caches and the YouTube resolver chain must both stay out of the way.
                     telegramFactory
+                } else if (normalizedScheme == DeezerCrypto.SCHEME) {
+                    // Carries its own cache; the YouTube resolver would rewrite the URI.
+                    deezerFactory
                 } else if (
                     normalizedScheme == "content" ||
                     normalizedScheme == "file" ||

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/PlayerMenu.kt
@@ -1496,6 +1496,7 @@ private fun AudioSourceType.sourceLabelRes(): Int =
     when (this) {
         AudioSourceType.TIDAL -> R.string.source_tidal
         AudioSourceType.QOBUZ -> R.string.source_qobuz
+        AudioSourceType.DEEZER -> R.string.source_deezer
         AudioSourceType.YOUTUBE -> R.string.source_youtube
     }
 
@@ -1503,6 +1504,7 @@ private fun AudioSourceType.sourceIconRes(): Int =
     when (this) {
         AudioSourceType.TIDAL -> R.drawable.provider_tidal
         AudioSourceType.QOBUZ -> R.drawable.provider_qobuz
+        AudioSourceType.DEEZER -> R.drawable.provider_deezer
         AudioSourceType.YOUTUBE -> R.drawable.play
     }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
@@ -71,6 +71,8 @@ import moe.rukamori.archivetune.ui.screens.settings.TidalLoginScreen
 import moe.rukamori.archivetune.ui.screens.settings.TIDAL_LOGIN_ROUTE
 import moe.rukamori.archivetune.ui.screens.settings.QobuzLoginScreen
 import moe.rukamori.archivetune.ui.screens.settings.QOBUZ_LOGIN_ROUTE
+import moe.rukamori.archivetune.ui.screens.settings.DEEZER_LOGIN_ROUTE
+import moe.rukamori.archivetune.ui.screens.settings.DeezerLoginScreen
 import moe.rukamori.archivetune.ui.screens.settings.TELEGRAM_LOGIN_ROUTE
 import moe.rukamori.archivetune.ui.screens.settings.TelegramLoginScreen
 import moe.rukamori.archivetune.ui.screens.settings.TelegramSettings
@@ -466,6 +468,9 @@ fun NavGraphBuilder.navigationBuilder(
     }
     composable(QOBUZ_LOGIN_ROUTE) {
         QobuzLoginScreen(navController)
+    }
+    composable(DEEZER_LOGIN_ROUTE) {
+        DeezerLoginScreen(navController)
     }
     composable("settings/telegram") {
         TelegramSettings(navController)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
@@ -60,6 +60,7 @@ import moe.rukamori.archivetune.ui.screens.settings.ContentSettings
 import moe.rukamori.archivetune.ui.screens.settings.CustomizeBackground
 import moe.rukamori.archivetune.ui.screens.settings.DebugSettings
 import moe.rukamori.archivetune.ui.screens.settings.DiscordSettings
+import moe.rukamori.archivetune.ui.screens.settings.ExportDownloadedSongsScreen
 import moe.rukamori.archivetune.ui.screens.settings.HiddenPlaylistsScreen
 import moe.rukamori.archivetune.ui.screens.settings.IconScreen
 import moe.rukamori.archivetune.ui.screens.settings.IntegrationScreen
@@ -438,6 +439,9 @@ fun NavGraphBuilder.navigationBuilder(
     }
     composable("settings/storage") {
         StorageSettings(navController)
+    }
+    composable("settings/storage/export_downloads") {
+        ExportDownloadedSongsScreen(navController)
     }
     composable("settings/privacy") {
         PrivacySettings(navController)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DeezerLoginScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DeezerLoginScreen.kt
@@ -1,0 +1,180 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ *
+ * WebView-based Deezer sign-in. Deezer has no OAuth flow we can use, so the credential is the `arl`
+ * session cookie the site sets on a signed-in browser. Mirrors the [TidalLoginScreen] WebView
+ * pattern and persists the cookie to DataStore.
+ */
+
+package moe.rukamori.archivetune.ui.screens.settings
+
+import android.annotation.SuppressLint
+import android.webkit.CookieManager
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import android.widget.Toast
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.datastore.preferences.core.edit
+import androidx.navigation.NavController
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
+import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.constants.DeezerAccountNameKey
+import moe.rukamori.archivetune.constants.DeezerAccountPremiumKey
+import moe.rukamori.archivetune.constants.DeezerArlKey
+import moe.rukamori.archivetune.constants.DeezerEnabledKey
+import moe.rukamori.archivetune.deezer.DeezerAudioProvider
+import moe.rukamori.archivetune.ui.component.IconButton
+import moe.rukamori.archivetune.ui.utils.backToMain
+import moe.rukamori.archivetune.utils.dataStore
+import moe.rukamori.archivetune.utils.resetAuthWebViewSession
+import java.util.concurrent.atomic.AtomicBoolean
+
+const val DEEZER_LOGIN_ROUTE = "settings/deezer/login"
+
+private const val LOGIN_URL = "https://www.deezer.com/login"
+
+/** Cookies are read for this origin; the `arl` cookie is scoped to `.deezer.com`. */
+private const val COOKIE_ORIGIN = "https://www.deezer.com"
+
+@SuppressLint("SetJavaScriptEnabled")
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DeezerLoginScreen(navController: NavController) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    // The cookie appears while the page is still navigating, so onPageFinished can fire several more
+    // times with it present. Without this guard each one would kick off its own verification.
+    val handled = remember { AtomicBoolean(false) }
+    // Deliberately remembered state, unlike the plain `var` in TidalLoginScreen/QobuzLoginScreen: a
+    // plain local resets to null on recomposition (the AndroidView factory only runs once) and never
+    // triggers one, which leaves the BackHandler below permanently disabled. Those two screens have
+    // the same latent bug; it is not fixed here to avoid touching unrelated flows.
+    var webView by remember { mutableStateOf<WebView?>(null) }
+
+    fun toast(message: String) {
+        Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+    }
+
+    /**
+     * Pulls `arl` out of the cookie jar. Read through [CookieManager] rather than `document.cookie`
+     * because the cookie is HttpOnly and therefore invisible to JavaScript.
+     */
+    fun readArl(): String? =
+        CookieManager
+            .getInstance()
+            .getCookie(COOKIE_ORIGIN)
+            ?.split(';')
+            ?.firstNotNullOfOrNull { part ->
+                val (name, value) = part.split('=', limit = 2).takeIf { it.size == 2 } ?: return@firstNotNullOfOrNull null
+                value.trim().takeIf { name.trim().equals("arl", ignoreCase = true) && it.isNotEmpty() }
+            }
+
+    fun finishLogin(arl: String) {
+        scope.launch {
+            // Verify before saving: Deezer also issues an `arl` to anonymous visitors, so its mere
+            // presence does not mean anyone signed in.
+            val info = withContext(Dispatchers.IO) { DeezerAudioProvider.verifyArl(arl) }
+            if (info == null) {
+                // Not signed in yet (or the cookie is stale) — let the user keep going rather than
+                // closing the screen on them.
+                handled.set(false)
+                return@launch
+            }
+            context.dataStore.edit { prefs ->
+                prefs[DeezerArlKey] = arl
+                prefs[DeezerAccountNameKey] = info.name
+                prefs[DeezerAccountPremiumKey] = info.lossless
+                // Signing in is an explicit opt-in to the source, which defaults off; leaving it off
+                // would make a successful login look like it did nothing.
+                prefs[DeezerEnabledKey] = true
+            }
+            // Push it immediately so playback works without waiting for the App-level collector.
+            DeezerAudioProvider.setManualArl(arl, info.lossless)
+            toast(context.getString(R.string.deezer_login_success, info.name))
+            navController.navigateUp()
+        }
+    }
+
+    AndroidView(
+        modifier =
+            Modifier
+                .windowInsetsPadding(LocalPlayerAwareWindowInsets.current)
+                .fillMaxSize(),
+        factory = { ctx ->
+            WebView(ctx).apply {
+                webViewClient =
+                    object : WebViewClient() {
+                        override fun onPageFinished(
+                            view: WebView,
+                            url: String?,
+                        ) {
+                            // Checked on every completed navigation rather than on a single redirect
+                            // URL: Deezer has no post-login redirect we control, and the cookie can
+                            // land on any of several pages depending on how the account signs in.
+                            val arl = readArl() ?: return
+                            if (!handled.compareAndSet(false, true)) return
+                            finishLogin(arl)
+                        }
+                    }
+                settings.apply {
+                    javaScriptEnabled = true
+                    domStorageEnabled = true
+                    setSupportZoom(true)
+                    builtInZoomControls = true
+                    displayZoomControls = false
+                }
+                webView = this
+                // Clearing cookies first means an already-signed-in browser session cannot hand back
+                // a stale ARL for an account the user is trying to switch away from.
+                resetAuthWebViewSession(ctx, this, clearCookies = true) {
+                    CookieManager.getInstance().setAcceptCookie(true)
+                    CookieManager.getInstance().setAcceptThirdPartyCookies(this, true)
+                    loadUrl(LOGIN_URL)
+                }
+            }
+        },
+    )
+
+    TopAppBar(
+        title = { Text(stringResource(R.string.deezer_login)) },
+        navigationIcon = {
+            IconButton(
+                onClick = navController::navigateUp,
+                onLongClick = navController::backToMain,
+            ) {
+                Icon(
+                    painterResource(R.drawable.arrow_back),
+                    contentDescription = null,
+                )
+            }
+        },
+    )
+
+    BackHandler(enabled = webView?.canGoBack() == true) {
+        webView?.goBack()
+    }
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ExportDownloadedSongsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ExportDownloadedSongsScreen.kt
@@ -285,4 +285,3 @@ private fun ExportActionBar(
         }
     }
 }
-</content>

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ExportDownloadedSongsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ExportDownloadedSongsScreen.kt
@@ -1,0 +1,288 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.ui.screens.settings
+
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavController
+import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
+import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.download.CacheExporter
+import moe.rukamori.archivetune.ui.component.IconButton
+import moe.rukamori.archivetune.ui.component.SongListItem
+import moe.rukamori.archivetune.ui.utils.backToMain
+import moe.rukamori.archivetune.viewmodels.ExportDownloadedSongsViewModel
+
+/**
+ * Lets the user pick WHICH downloaded songs to export, as opposed to the all-or-nothing
+ * "Export downloaded songs" action in [StorageSettings].
+ *
+ * This is a front-end only. The copy/tag/cancel work stays in [CacheExporter], which already accepts
+ * an arbitrary song list, so both entry points share one engine and one progress surface. That also
+ * means an export started here keeps running after navigating away, and is still reported when the
+ * user comes back.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ExportDownloadedSongsScreen(
+    navController: NavController,
+    viewModel: ExportDownloadedSongsViewModel = hiltViewModel(),
+) {
+    val context = LocalContext.current
+    val songs by viewModel.songs.collectAsStateWithLifecycle()
+    val loading by viewModel.loading.collectAsStateWithLifecycle()
+    val exportProgress by CacheExporter.progress.collectAsStateWithLifecycle()
+
+    // Survives process death so a selection is not silently lost while the SAF folder picker — a
+    // separate activity — is in the foreground. Saved through an explicit List<String> saver: a raw
+    // Set has no built-in saver, so relying on the default would depend on the concrete set
+    // implementation happening to be Serializable.
+    val selectedIds =
+        rememberSaveable(
+            stateSaver =
+                listSaver<Set<String>, String>(
+                    save = { it.toList() },
+                    restore = { it.toSet() },
+                ),
+        ) { mutableStateOf(emptySet<String>()) }
+
+    // Songs load asynchronously and a download can be cleared elsewhere, so drop ids that no longer
+    // exist rather than counting them towards the selection and exporting nothing for them.
+    val availableIds = remember(songs) { songs.map { it.song.id }.toSet() }
+    LaunchedEffect(availableIds) {
+        selectedIds.value = selectedIds.value intersect availableIds
+    }
+
+    val isExporting = exportProgress?.running == true
+    val allSelected = songs.isNotEmpty() && selectedIds.value.size == songs.size
+
+    val exportFolderLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { treeUri ->
+            treeUri?.let { viewModel.export(it, selectedIds.value) }
+        }
+
+    LaunchedEffect(exportProgress?.running) {
+        val finished =
+            exportProgress?.takeIf { !it.running && it.processed > 0 } ?: return@LaunchedEffect
+        Toast.makeText(context, finished.summary(context), Toast.LENGTH_LONG).show()
+        CacheExporter.clearProgress()
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.export_downloaded_songs)) },
+                navigationIcon = {
+                    IconButton(
+                        onClick = navController::navigateUp,
+                        onLongClick = navController::backToMain,
+                    ) {
+                        Icon(
+                            painterResource(R.drawable.arrow_back),
+                            contentDescription = null,
+                        )
+                    }
+                },
+                actions = {
+                    if (songs.isNotEmpty()) {
+                        TextButton(
+                            onClick = {
+                                selectedIds.value =
+                                    if (allSelected) emptySet() else availableIds
+                            },
+                        ) {
+                            Text(
+                                stringResource(
+                                    if (allSelected) R.string.deselect_all else R.string.select_all,
+                                ),
+                            )
+                        }
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            Modifier
+                .fillMaxSize()
+                .padding(top = innerPadding.calculateTopPadding())
+                .windowInsetsPadding(
+                    LocalPlayerAwareWindowInsets.current.only(
+                        WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
+                    ),
+                ),
+        ) {
+            when {
+                loading ->
+                    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator()
+                    }
+
+                songs.isEmpty() ->
+                    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Text(
+                            text = stringResource(R.string.no_downloads),
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+
+                else ->
+                    LazyColumn(Modifier.weight(1f)) {
+                        items(songs, key = { it.song.id }) { song ->
+                            val isSelected = song.song.id in selectedIds.value
+                            SongListItem(
+                                song = song,
+                                showDownloadIcon = false,
+                                trailingContent = {
+                                    Checkbox(
+                                        checked = isSelected,
+                                        // The whole row toggles; a nested clickable target here would
+                                        // just intercept taps meant for the row.
+                                        onCheckedChange = null,
+                                    )
+                                },
+                                modifier =
+                                    Modifier.clickable(enabled = !isExporting) {
+                                        selectedIds.value =
+                                            if (isSelected) {
+                                                selectedIds.value - song.song.id
+                                            } else {
+                                                selectedIds.value + song.song.id
+                                            }
+                                    },
+                            )
+                        }
+                    }
+            }
+
+            if (songs.isNotEmpty()) {
+                ExportActionBar(
+                    selectedCount = selectedIds.value.size,
+                    totalCount = songs.size,
+                    progress = exportProgress,
+                    onExport = { exportFolderLauncher.launch(null) },
+                    onCancel = CacheExporter::cancel,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Pinned footer: selection count, live progress and the export/cancel trigger.
+ *
+ * Kept out of the scrolling list so the primary action stays reachable in a library of thousands of
+ * songs, where a footer inside the list would sit thousands of rows down.
+ */
+@Composable
+private fun ExportActionBar(
+    selectedCount: Int,
+    totalCount: Int,
+    progress: CacheExporter.Progress?,
+    onExport: () -> Unit,
+    onCancel: () -> Unit,
+) {
+    val isExporting = progress?.running == true
+
+    Surface(tonalElevation = 3.dp) {
+        Column(Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp)) {
+            HorizontalDivider(Modifier.padding(bottom = 12.dp))
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Column(Modifier.weight(1f)) {
+                    Text(
+                        text =
+                            stringResource(
+                                R.string.export_selected_of_total,
+                                selectedCount,
+                                totalCount,
+                            ),
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    if (isExporting && progress != null) {
+                        Text(
+                            text =
+                                stringResource(
+                                    R.string.export_in_progress,
+                                    progress.processed,
+                                    progress.total,
+                                ),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+
+                if (isExporting) {
+                    TextButton(onClick = onCancel) {
+                        Text(stringResource(R.string.cancel_button))
+                    }
+                } else {
+                    Button(onClick = onExport, enabled = selectedCount > 0) {
+                        Text(stringResource(R.string.export))
+                    }
+                }
+            }
+
+            if (isExporting && progress != null && progress.total > 0) {
+                LinearProgressIndicator(
+                    progress = { progress.processed.toFloat() / progress.total },
+                    modifier = Modifier.fillMaxWidth().padding(top = 12.dp),
+                )
+            }
+        }
+    }
+}
+</content>

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlaybackSourceSections.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlaybackSourceSections.kt
@@ -50,6 +50,9 @@ import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.audiosource.AudioSourceConfig
 import moe.rukamori.archivetune.constants.AudioSourceOrderKey
 import moe.rukamori.archivetune.constants.AudioSourceType
+import moe.rukamori.archivetune.constants.DeezerAccountNameKey
+import moe.rukamori.archivetune.constants.DeezerAccountPremiumKey
+import moe.rukamori.archivetune.constants.DeezerArlKey
 import moe.rukamori.archivetune.constants.DeezerAudioQuality
 import moe.rukamori.archivetune.constants.DeezerAudioQualityKey
 import moe.rukamori.archivetune.constants.DeezerEnabledKey
@@ -111,6 +114,10 @@ fun PlaybackSourceSections(navController: NavController) {
     val (tidalEnabled, onTidalEnabledChange) = rememberPreference(TidalEnabledKey, true)
     val (qobuzEnabled, onQobuzEnabledChange) = rememberPreference(QobuzEnabledKey, false)
     val (deezerEnabled, onDeezerEnabledChange) = rememberPreference(DeezerEnabledKey, false)
+    // Only the setters are needed here; the ARL and tier themselves are never shown in settings.
+    val (_, onDeezerArlChange) = rememberPreference(DeezerArlKey, "")
+    val (deezerAccountName, onDeezerAccountNameChange) = rememberPreference(DeezerAccountNameKey, "")
+    val (_, onDeezerAccountPremiumChange) = rememberPreference(DeezerAccountPremiumKey, false)
 
     // The Integration screen only shows its per-service login entries when this Debug flag is
     // on, so the "manage in Integration" shortcuts below would otherwise lead nowhere useful.
@@ -394,6 +401,36 @@ fun PlaybackSourceSections(navController: NavController) {
                     }
                 },
             )
+        }
+
+        // A manual sign-in is offered regardless of `manualSourceLogin`: that flag gates self-hosted
+        // proxy instances, which Deezer does not have. Signing in here is the only way to use Deezer
+        // without waiting on the shared pool.
+        if (deezerAccountName.isEmpty()) {
+            item {
+                PreferenceEntry(
+                    title = { Text(stringResource(R.string.deezer_login)) },
+                    description = stringResource(R.string.deezer_login_description),
+                    icon = { Icon(painterResource(R.drawable.token), null) },
+                    isEnabled = deezerEnabled,
+                    onClick = { navController.navigate(DEEZER_LOGIN_ROUTE) },
+                )
+            }
+        } else {
+            item {
+                PreferenceEntry(
+                    title = { Text(stringResource(R.string.deezer_sign_out)) },
+                    description = stringResource(R.string.deezer_signed_in_as, deezerAccountName),
+                    icon = { Icon(painterResource(R.drawable.logout), null) },
+                    onClick = {
+                        // Clearing the ARL is what actually signs out; App.kt's collector observes it
+                        // and drops the provider's session. Name/premium are display state only.
+                        onDeezerArlChange("")
+                        onDeezerAccountNameChange("")
+                        onDeezerAccountPremiumChange(false)
+                    },
+                )
+            }
         }
     }
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlaybackSourceSections.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlaybackSourceSections.kt
@@ -86,6 +86,7 @@ private fun AudioSourceType.displayName(context: android.content.Context): Strin
     when (this) {
         AudioSourceType.TIDAL -> context.getString(R.string.source_tidal)
         AudioSourceType.QOBUZ -> context.getString(R.string.source_qobuz)
+        AudioSourceType.DEEZER -> context.getString(R.string.source_deezer)
         AudioSourceType.YOUTUBE -> context.getString(R.string.source_youtube)
     }
 
@@ -93,13 +94,14 @@ private fun AudioSourceType.iconRes(): Int =
     when (this) {
         AudioSourceType.TIDAL -> R.drawable.provider_tidal
         AudioSourceType.QOBUZ -> R.drawable.provider_qobuz
+        AudioSourceType.DEEZER -> R.drawable.provider_deezer
         AudioSourceType.YOUTUBE -> R.drawable.play
     }
 
 /**
  * Renders all streaming-source preference groups inline in the caller's scrolling Column. Meant to
  * be called from [PlayerSettings]. Emits, in order: the common "Sources" group (preferred-source
- * picker + YouTube history sync), then YouTube, Tidal and Qobuz specific groups.
+ * picker + YouTube history sync), then YouTube, Tidal, Qobuz and Deezer specific groups.
  */
 @Composable
 fun PlaybackSourceSections(navController: NavController) {
@@ -170,6 +172,7 @@ fun PlaybackSourceSections(navController: NavController) {
         when (source) {
             AudioSourceType.TIDAL -> tidalEnabled
             AudioSourceType.QOBUZ -> qobuzEnabled
+            AudioSourceType.DEEZER -> deezerEnabled
             AudioSourceType.YOUTUBE -> true
         }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlaybackSourceSections.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlaybackSourceSections.kt
@@ -14,6 +14,7 @@
 
 package moe.rukamori.archivetune.ui.screens.settings
 
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
@@ -428,6 +429,11 @@ fun PlaybackSourceSections(navController: NavController) {
                         onDeezerArlChange("")
                         onDeezerAccountNameChange("")
                         onDeezerAccountPremiumChange(false)
+                        // The row swapping back to "Sign in" is easy to miss on its own as
+                        // confirmation that anything happened.
+                        Toast
+                            .makeText(context, R.string.deezer_signed_out, Toast.LENGTH_SHORT)
+                            .show()
                     },
                 )
             }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlaybackSourceSections.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlaybackSourceSections.kt
@@ -7,7 +7,7 @@
  * Streaming-source sections rendered inline inside Player & Audio settings:
  *  - a single lyrics-style drag-to-reorder "preferred sources" picker (top = preferred),
  *  - a common section (YouTube history sync),
- *  - and per-source sections (YouTube note, Tidal, Qobuz).
+ *  - and per-source sections (YouTube note, Tidal, Qobuz, Deezer).
  *
  * Account login / instance / API management lives in the Integration section, not here.
  */
@@ -50,6 +50,9 @@ import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.audiosource.AudioSourceConfig
 import moe.rukamori.archivetune.constants.AudioSourceOrderKey
 import moe.rukamori.archivetune.constants.AudioSourceType
+import moe.rukamori.archivetune.constants.DeezerAudioQuality
+import moe.rukamori.archivetune.constants.DeezerAudioQualityKey
+import moe.rukamori.archivetune.constants.DeezerEnabledKey
 import moe.rukamori.archivetune.constants.ManualSourceLoginEnabledKey
 import moe.rukamori.archivetune.constants.QobuzAudioQuality
 import moe.rukamori.archivetune.constants.QobuzAudioQualityKey
@@ -105,6 +108,7 @@ fun PlaybackSourceSections(navController: NavController) {
     val (sourceOrderRaw, onSourceOrderChange) = rememberPreference(AudioSourceOrderKey, "")
     val (tidalEnabled, onTidalEnabledChange) = rememberPreference(TidalEnabledKey, true)
     val (qobuzEnabled, onQobuzEnabledChange) = rememberPreference(QobuzEnabledKey, false)
+    val (deezerEnabled, onDeezerEnabledChange) = rememberPreference(DeezerEnabledKey, false)
 
     // The Integration screen only shows its per-service login entries when this Debug flag is
     // on, so the "manage in Integration" shortcuts below would otherwise lead nowhere useful.
@@ -151,6 +155,8 @@ fun PlaybackSourceSections(navController: NavController) {
     }
     val (qobuzQuality, onQobuzQualityChange) =
         rememberEnumPreference(QobuzAudioQualityKey, QobuzAudioQuality.FLAC)
+    val (deezerQuality, onDeezerQualityChange) =
+        rememberEnumPreference(DeezerAudioQualityKey, DeezerAudioQuality.FLAC)
     // The Tidal artwork-fetching toggle lives in Player Settings → Artwork (same key).
     val (animatedCovers, onAnimatedCoversChange) =
         rememberPreference(TidalAnimatedCoversEnabledKey, false)
@@ -354,6 +360,37 @@ fun PlaybackSourceSections(navController: NavController) {
                     onClick = { navController.navigate("settings/integration") },
                 )
             }
+        }
+    }
+
+    // Deezer has no proxy-instance or per-account tier to manage, so unlike Tidal/Qobuz there is no
+    // "manage in Integration" row here — accounts arrive via the pool.
+    PreferenceGroup(title = stringResource(R.string.deezer_specific)) {
+        item {
+            SwitchPreference(
+                title = { Text(stringResource(R.string.deezer_enable)) },
+                description = stringResource(R.string.deezer_enable_description),
+                icon = { Icon(painterResource(R.drawable.provider_deezer), null) },
+                checked = deezerEnabled,
+                onCheckedChange = onDeezerEnabledChange,
+            )
+        }
+
+        item {
+            EnumListPreference(
+                title = { Text(stringResource(R.string.deezer_audio_quality)) },
+                icon = { Icon(painterResource(R.drawable.play), null) },
+                selectedValue = deezerQuality,
+                onValueSelected = onDeezerQualityChange,
+                isEnabled = deezerEnabled,
+                valueText = { quality ->
+                    when (quality) {
+                        DeezerAudioQuality.FLAC -> stringResource(R.string.deezer_quality_flac)
+                        DeezerAudioQuality.MP3_320 -> stringResource(R.string.deezer_quality_mp3_320)
+                        DeezerAudioQuality.MP3_128 -> stringResource(R.string.deezer_quality_mp3_128)
+                    }
+                },
+            )
         }
     }
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlayerSettings.kt
@@ -469,6 +469,7 @@ fun PlayerSettings(navController: NavController) {
                                 DownloadSource.AUTO -> stringResource(R.string.download_source_auto)
                                 DownloadSource.QOBUZ -> stringResource(R.string.download_source_qobuz)
                                 DownloadSource.TIDAL -> stringResource(R.string.download_source_tidal)
+                                DownloadSource.DEEZER -> stringResource(R.string.download_source_deezer)
                                 DownloadSource.YOUTUBE_MUSIC -> stringResource(R.string.download_source_youtube_music)
                             }
                         },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsAnchors.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsAnchors.kt
@@ -149,6 +149,7 @@ object SettingsAnchors {
 
     // Storage
     const val EXPORT_DOWNLOADS = "export_downloads"
+    const val EXPORT_DOWNLOADS_PICK = "export_downloads_pick"
     const val CLEAR_DOWNLOADS = "clear_downloads"
     const val SONG_CACHE_SIZE = "song_cache_size"
     const val CLEAR_SONG_CACHE = "clear_song_cache"

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
@@ -77,7 +77,7 @@ fun buildSettingsGroups(
             title = stringResource(R.string.source_settings),
             subtitle = stringResource(R.string.source_settings_subtitle),
             accentColor = MaterialTheme.colorScheme.tertiary,
-            keywords = listOf("source", "music source", "youtube music", "tidal", "qobuz", "provider", "streaming"),
+            keywords = listOf("source", "music source", "youtube music", "tidal", "qobuz", "deezer", "provider", "streaming"),
             onClick = { navController.navigate("settings/sources") },
         )
     val lyrics =

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
@@ -688,6 +688,16 @@ internal fun buildDeepSettingsEntries(navController: NavController): DeepSetting
         deepEntry(
             navController = navController,
             screen = SettingsAnchorScreens.STORAGE,
+            anchor = SettingsAnchors.EXPORT_DOWNLOADS_PICK,
+            icon = storageIcon,
+            title = stringResource(R.string.export_choose_songs),
+            parentTitle = storageTitle,
+            accentColor = storageAccent,
+            keywords = listOf("export selected", "select songs", "pick songs", "export some", "partial export"),
+        ),
+        deepEntry(
+            navController = navController,
+            screen = SettingsAnchorScreens.STORAGE,
             anchor = SettingsAnchors.CLEAR_DOWNLOADS,
             icon = storageIcon,
             title = stringResource(R.string.clear_all_downloads),

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/StorageSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/StorageSettings.kt
@@ -399,6 +399,22 @@ fun StorageSettings(
                         onClick = { exportFolderLauncher.launch(null) },
                     )
                 }
+                item {
+                    PreferenceEntry(
+                        modifier = anchors.anchor(SettingsAnchors.EXPORT_DOWNLOADS_PICK),
+                        title = { Text(stringResource(R.string.export_choose_songs)) },
+                        description = stringResource(R.string.export_choose_songs_description),
+                        icon = {
+                            Icon(
+                                painter = painterResource(R.drawable.ic_download),
+                                contentDescription = null,
+                            )
+                        },
+                        // Not disabled while an export runs: the picker shows that run's live progress,
+                        // and blocking the way in would hide it from anyone who did not start it here.
+                        onClick = { navController.navigate("settings/storage/export_downloads") },
+                    )
+                }
             }
 
             if (clearDownloads) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/utils/PoolAccountManager.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/utils/PoolAccountManager.kt
@@ -51,6 +51,7 @@ object PoolAccountManager {
 
     private val CACHE_TIDAL_KEY = stringPreferencesKey("poolTidalAccounts")
     private val CACHE_QOBUZ_KEY = stringPreferencesKey("poolQobuzAccounts")
+    private val CACHE_DEEZER_KEY = stringPreferencesKey("poolDeezerAccounts")
 
     /** A shared Tidal subscriber token contributed to the pool. */
     data class TidalPoolAccount(
@@ -68,11 +69,27 @@ object PoolAccountManager {
         val premium: Boolean,
     )
 
+    /**
+     * A shared Deezer subscriber credential.
+     *
+     * Deezer authenticates with the `arl` cookie rather than a bearer token, and [premium] false means
+     * the account has no lossless entitlement, so it can still serve MP3 but will refuse FLAC.
+     */
+    data class DeezerPoolAccount(
+        val arl: String,
+        val premium: Boolean,
+        /** Optional override for the Blowfish key salt; null means use the salt the app ships with. */
+        val masterSecret: String? = null,
+    )
+
     @Volatile
     private var tidalCache: List<TidalPoolAccount> = emptyList()
 
     @Volatile
     private var qobuzCache: List<QobuzPoolAccount> = emptyList()
+
+    @Volatile
+    private var deezerCache: List<DeezerPoolAccount> = emptyList()
 
     @Volatile
     private var lastRefreshAt = 0L
@@ -107,7 +124,9 @@ object PoolAccountManager {
 
     fun qobuzAccounts(): List<QobuzPoolAccount> = qobuzCache.sortedByDescending { it.premium }
 
-    fun hasAccounts(): Boolean = tidalCache.isNotEmpty() || qobuzCache.isNotEmpty()
+    fun deezerAccounts(): List<DeezerPoolAccount> = deezerCache.sortedByDescending { it.premium }
+
+    fun hasAccounts(): Boolean = tidalCache.isNotEmpty() || qobuzCache.isNotEmpty() || deezerCache.isNotEmpty()
 
     /**
      * Loads the persisted account cache into memory (cheap, no network). Safe to call repeatedly;
@@ -124,8 +143,16 @@ object PoolAccountManager {
                 context.dataStore.getAsync(CACHE_QOBUZ_KEY)?.takeIf { it.isNotBlank() }?.let {
                     qobuzCache = parseQobuz(JSONArray(it))
                 }
+                context.dataStore.getAsync(CACHE_DEEZER_KEY)?.takeIf { it.isNotBlank() }?.let {
+                    deezerCache = parseDeezer(JSONArray(it))
+                }
                 loadedFromDisk = true
-                Timber.tag(TAG).d("Loaded cached accounts: tidal=%d qobuz=%d", tidalCache.size, qobuzCache.size)
+                Timber.tag(TAG).d(
+                    "Loaded cached accounts: tidal=%d qobuz=%d deezer=%d",
+                    tidalCache.size,
+                    qobuzCache.size,
+                    deezerCache.size,
+                )
             }.onFailure { Timber.tag(TAG).w(it, "Failed to load cached pool accounts") }
         }
     }
@@ -167,11 +194,18 @@ object PoolAccountManager {
                         val root = JSONObject(response.body?.string().orEmpty())
                         val tidal = parseTidal(root.optJSONObject("tidal")?.optJSONArray("accounts"))
                         val qobuz = parseQobuz(root.optJSONObject("qobuz")?.optJSONArray("accounts"))
+                        val deezer = parseDeezer(root.optJSONObject("deezer")?.optJSONArray("accounts"))
                         tidalCache = tidal
                         qobuzCache = qobuz
+                        deezerCache = deezer
                         lastRefreshAt = System.currentTimeMillis()
-                        persist(context, tidal, qobuz)
-                        Timber.tag(TAG).i("Pool accounts refreshed: tidal=%d qobuz=%d", tidal.size, qobuz.size)
+                        persist(context, tidal, qobuz, deezer)
+                        Timber.tag(TAG).i(
+                            "Pool accounts refreshed: tidal=%d qobuz=%d deezer=%d",
+                            tidal.size,
+                            qobuz.size,
+                            deezer.size,
+                        )
                     }
                 }.onFailure { Timber.tag(TAG).w(it, "Pool account refresh failed") }
                 hasAccounts()
@@ -182,6 +216,7 @@ object PoolAccountManager {
         context: Context,
         tidal: List<TidalPoolAccount>,
         qobuz: List<QobuzPoolAccount>,
+        deezer: List<DeezerPoolAccount>,
     ) {
         val tidalJson =
             JSONArray().apply {
@@ -207,10 +242,22 @@ object PoolAccountManager {
                     )
                 }
             }.toString()
+        val deezerJson =
+            JSONArray().apply {
+                deezer.forEach {
+                    put(
+                        JSONObject()
+                            .put("arl", it.arl)
+                            .put("masterSecret", it.masterSecret)
+                            .put("premium", it.premium),
+                    )
+                }
+            }.toString()
         runCatching {
             context.dataStore.edit { prefs ->
                 prefs[CACHE_TIDAL_KEY] = tidalJson
                 prefs[CACHE_QOBUZ_KEY] = qobuzJson
+                prefs[CACHE_DEEZER_KEY] = deezerJson
             }
         }.onFailure { Timber.tag(TAG).w(it, "Failed to persist pool accounts") }
     }
@@ -258,6 +305,22 @@ object PoolAccountManager {
                     appId = appId,
                     appSecret = appSecret,
                     premium = obj.optBoolean("premium", false),
+                )
+        }
+        return out
+    }
+
+    private fun parseDeezer(arr: JSONArray?): List<DeezerPoolAccount> {
+        if (arr == null) return emptyList()
+        val out = mutableListOf<DeezerPoolAccount>()
+        for (i in 0 until arr.length()) {
+            val obj = arr.optJSONObject(i) ?: continue
+            val arl = field(obj, "arl") ?: continue
+            out +=
+                DeezerPoolAccount(
+                    arl = arl,
+                    premium = obj.optBoolean("premium", false),
+                    masterSecret = field(obj, "masterSecret"),
                 )
         }
         return out

--- a/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/ExportDownloadedSongsViewModel.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/ExportDownloadedSongsViewModel.kt
@@ -111,4 +111,3 @@ class ExportDownloadedSongsViewModel
             }
         }
     }
-</content>

--- a/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/ExportDownloadedSongsViewModel.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/ExportDownloadedSongsViewModel.kt
@@ -1,0 +1,114 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.viewmodels
+
+import android.content.Context
+import android.net.Uri
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.media3.datasource.cache.Cache
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import moe.rukamori.archivetune.constants.LosslessDownloadTagKey
+import moe.rukamori.archivetune.db.MusicDatabase
+import moe.rukamori.archivetune.db.entities.Song
+import moe.rukamori.archivetune.di.DownloadCache
+import moe.rukamori.archivetune.download.CacheExporter
+import moe.rukamori.archivetune.utils.dataStore
+import moe.rukamori.archivetune.utils.get
+import javax.inject.Inject
+
+/**
+ * Backs the export picker: lists what is actually downloaded and hands a chosen subset to
+ * [CacheExporter].
+ *
+ * Deliberately does NOT own an export engine. `CacheExporter.export` already takes an arbitrary
+ * `List<Song>`, runs on a process-lived scope and publishes progress, so a selection screen only
+ * needs to supply the subset — duplicating the copy/tag logic here would fork the tagging and
+ * cancellation behaviour that the existing "export everything" path already has.
+ */
+@HiltViewModel
+class ExportDownloadedSongsViewModel
+    @Inject
+    constructor(
+        @ApplicationContext private val context: Context,
+        private val database: MusicDatabase,
+        @DownloadCache private val downloadCache: Cache,
+    ) : ViewModel() {
+        private val _songs = MutableStateFlow<List<Song>>(emptyList())
+
+        /** Downloaded songs, newest download first. Empty until [refresh] completes. */
+        val songs: StateFlow<List<Song>> = _songs.asStateFlow()
+
+        private val _loading = MutableStateFlow(true)
+        val loading: StateFlow<Boolean> = _loading.asStateFlow()
+
+        init {
+            refresh()
+        }
+
+        /**
+         * Re-reads the download cache.
+         *
+         * Loaded once per call rather than polled on a timer: an export picker is a snapshot the user
+         * is actively selecting within, and swapping rows underneath a part-made selection would
+         * silently change what "export" is about to write.
+         */
+        fun refresh() {
+            viewModelScope.launch {
+                _loading.value = true
+                _songs.value =
+                    withContext(Dispatchers.IO) {
+                        // Cache keys can be path-prefixed, so normalise before matching the db —
+                        // same normalisation ExportDownloadsUseCase does for the export-all path.
+                        val ids = downloadCache.keys.map { it.substringAfterLast("/") }.distinct()
+                        if (ids.isEmpty()) {
+                            emptyList()
+                        } else {
+                            database
+                                .getSongsByIds(ids)
+                                .sortedByDescending { it.song.dateDownload }
+                        }
+                    }
+                _loading.value = false
+            }
+        }
+
+        /**
+         * Exports [selectedIds] into [treeUri]. Ignored when nothing is selected.
+         *
+         * Progress and the final summary come from [CacheExporter.progress], which the screen
+         * observes directly, because the run outlives this ViewModel.
+         */
+        fun export(
+            treeUri: Uri,
+            selectedIds: Set<String>,
+        ) {
+            if (selectedIds.isEmpty() || CacheExporter.isRunning) return
+            val selected = _songs.value.filter { it.song.id in selectedIds }
+            if (selected.isEmpty()) return
+
+            viewModelScope.launch {
+                val embedTags = context.dataStore.get(LosslessDownloadTagKey, true)
+                CacheExporter.export(
+                    context = context,
+                    cache = downloadCache,
+                    treeUri = treeUri,
+                    songs = selected,
+                    embedTags = embedTags,
+                )
+            }
+        }
+    }
+</content>

--- a/app/src/main/res/drawable/provider_deezer.xml
+++ b/app/src/main/res/drawable/provider_deezer.xml
@@ -1,0 +1,13 @@
+<!--
+  Deezer's mark: four rows of stacked equaliser bars. Drawn as plain rectangles in a single path so
+  it tints like the other provider icons (see provider_qobuz.xml) instead of shipping brand colours.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M15.5,5h5.5v2.4h-5.5zM15.5,9.2h5.5v2.4h-5.5zM8.25,9.2h5.5v2.4h-5.5zM15.5,13.4h5.5v2.4h-5.5zM8.25,13.4h5.5v2.4h-5.5zM1,13.4h5.5v2.4h-5.5zM15.5,17.6h5.5v2.4h-5.5zM8.25,17.6h5.5v2.4h-5.5zM1,17.6h5.5v2.4h-5.5z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -223,6 +223,11 @@
     <string name="export_in_progress">Exporting %1$d of %2$d…</string>
     <string name="export_nothing_to_do">No downloaded songs to export</string>
     <string name="export_already_running">An export is already running</string>
+    <string name="export_choose_songs">Choose songs to export</string>
+    <string name="export_choose_songs_description">Pick individual downloads instead of exporting everything</string>
+    <string name="export_selected_of_total">%1$d of %2$d selected</string>
+    <string name="select_all">Select all</string>
+    <string name="deselect_all">Deselect all</string>
     <string name="import_playlist">Import playlist</string>
     <string name="import_failed">Import failed</string>
     <string name="update_button">Update</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -826,6 +826,16 @@
     <string name="tidal_instance_preview_only">Deprecated — %1$d ms</string>
     <string name="tidal_instance_unknown">Not tested — tap Test instances</string>
 
+    <!-- Deezer music source integration -->
+    <string name="deezer_specific">Deezer</string>
+    <string name="source_deezer">Deezer</string>
+    <string name="deezer_enable">Enable Deezer source</string>
+    <string name="deezer_enable_description">Route playback through shared Deezer accounts when a matching track is found</string>
+    <string name="deezer_audio_quality">Audio quality</string>
+    <string name="deezer_quality_flac">FLAC (CD 16-bit)</string>
+    <string name="deezer_quality_mp3_320">MP3 320 kbps</string>
+    <string name="deezer_quality_mp3_128">MP3 128 kbps</string>
+
     <!-- Qobuz music source integration -->
     <string name="source_qobuz">Qobuz</string>
     <string name="qobuz_integration">Qobuz</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -841,6 +841,13 @@
     <string name="deezer_quality_flac">FLAC (CD 16-bit)</string>
     <string name="deezer_quality_mp3_320">MP3 320 kbps</string>
     <string name="deezer_quality_mp3_128">MP3 128 kbps</string>
+    <string name="deezer_login">Sign in to Deezer</string>
+    <string name="deezer_login_description">Use your own Deezer account instead of the shared pool</string>
+    <string name="deezer_login_success">Signed in to Deezer as %1$s</string>
+    <string name="deezer_signed_in_as">Signed in as %1$s</string>
+    <string name="deezer_sign_out">Sign out of Deezer</string>
+    <string name="deezer_sign_out_description">Removes the stored session cookie from this device</string>
+    <string name="deezer_signed_out">Signed out of Deezer</string>
 
     <!-- Qobuz music source integration -->
     <string name="source_qobuz">Qobuz</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -185,11 +185,12 @@
         <item quantity="other">Export %1$d songs</item>
     </plurals>
     <string name="download_source_title">Download source</string>
-    <string name="download_source_description">Where downloads fetch audio from. Automatic tries each lossless service in turn. Qobuz and Tidal need a configured account and fall back to YouTube Music when no match is found.</string>
+    <string name="download_source_description">Where downloads fetch audio from. Automatic tries each lossless service in turn. Qobuz, Tidal and Deezer need a configured account and fall back to YouTube Music when no match is found.</string>
     <string name="download_source_auto">Automatic (best available)</string>
     <string name="download_source_youtube_music">YouTube Music</string>
     <string name="download_source_tidal">Tidal</string>
     <string name="download_source_qobuz">Qobuz</string>
+    <string name="download_source_deezer">Deezer</string>
     <string name="download_quality_title">Download quality</string>
     <string name="download_quality_max">Max</string>
     <string name="download_quality_max_description">Best the source offers, up to 24-bit/192 kHz</string>


### PR DESCRIPTION
Phase B1+B2 of the Deezer port. Opened as a draft to run `Build Pull Request` for compile validation, since Android cannot be built locally.

Adds the self-contained parts of the Deezer source:
- gateway auth from pooled ARL cookies
- catalog search with shared track matching (`TrackMatching.best`)
- media-endpoint stream URL resolution
- a Media3 `DataSource` that undoes `BF_CBC_STRIPE` chunk encryption in flight

The provider returns its own `Resolved` type instead of the playback layer's `DirectStream`, so this commit compiles without touching source resolution. `AudioSourceType` is unchanged and Deezer is not yet selectable — routing for playback and downloads lands in a follow-up.

Not ready to merge: the settings UI, preference keys and string/icon resources are still to come.