### PR TITLE
ci: restore stable release workflow, without the repeating changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,600 @@
+name: Bump to new version
+on:
+  push:
+    branches:
+      - 'main'
+  workflow_dispatch:
+
+concurrency:
+  # Serialize main releases so concurrent pushes don't create clashing tags.
+  group: stable-release
+  cancel-in-progress: false
+
+jobs:
+  check-version:
+    if: contains(github.ref, 'refs/tags') == false
+    runs-on: ubuntu-latest
+    outputs:
+      version_changed: ${{ steps.check_version.outputs.version_changed }}
+      new_version: ${{ steps.check_version.outputs.new_version }}
+      version_code: ${{ steps.check_version.outputs.version_code }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Compute auto-bumped version
+        id: check_version
+        run: |
+          set -euo pipefail
+          if [ ! -f app/build.gradle.kts ]; then
+            echo "Error: app/build.gradle.kts does not exist"
+            exit 1
+          fi
+
+          # Base major.minor comes from the committed versionName (bump it manually for a big
+          # release, e.g. 13.7.x -> 14.0.x). The patch and versionCode are derived from the git
+          # commit count so every push to main yields a strictly-increasing, installable release
+          # with no commit-back loop.
+          BASE_VERSION="$(grep -oP 'baseVersionName\s*=\s*"\K[^"]+' app/build.gradle.kts || echo '')"
+          if [ -z "$BASE_VERSION" ]; then
+            echo "Error: Could not find baseVersionName in app/build.gradle.kts"
+            exit 1
+          fi
+          MAJOR_MINOR="$(echo "$BASE_VERSION" | cut -d. -f1-2)"
+
+          COMMIT_COUNT="$(git rev-list --count HEAD)"
+          NEW_VERSION="${MAJOR_MINOR}.${COMMIT_COUNT}"
+          VERSION_CODE="$COMMIT_COUNT"
+
+          echo "Base version: $BASE_VERSION -> new version: $NEW_VERSION (code $VERSION_CODE)"
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "version_code=$VERSION_CODE" >> "$GITHUB_OUTPUT"
+
+          # Skip only if this exact version tag somehow already exists (e.g. a re-run).
+          if git rev-parse "v$NEW_VERSION" >/dev/null 2>&1; then
+            echo "Tag v$NEW_VERSION already exists. Skipping release."
+            echo "version_changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Tag v$NEW_VERSION does not exist. Proceeding with release."
+            echo "version_changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Debug output
+        run: |
+          echo "version_changed: ${{ steps.check_version.outputs.version_changed }}"
+          echo "new_version: ${{ steps.check_version.outputs.new_version }}"
+          echo "version_code: ${{ steps.check_version.outputs.version_code }}"
+
+  reproducibility:
+    needs: check-version
+    if: needs.check-version.outputs.version_changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Set Up Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-cleanup: on-success
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Verify reproducible unsigned universal APK
+        shell: bash
+        env:
+          LASTFM_API_KEY: ${{ secrets.LASTFM_API_KEY }}
+          LASTFM_SECRET: ${{ secrets.LASTFM_SECRET }}
+          API_BEARER_TOKEN: ${{ secrets.API_BEARER_TOKEN }}
+          TOGETHER_BEARER_TOKEN: ${{ secrets.TOGETHER_BEARER_TOKEN }}
+          CANVAS_BEARER_TOKEN: ${{ secrets.CANVAS_BEARER_TOKEN }}
+          EXTRACTOR_BEARER: ${{ secrets.EXTRACTOR_BEARER }}
+        run: |
+          set -euo pipefail
+          DEVICE="mobile"
+          DEVICE_CAP="Mobile"
+          ABI="universal"
+          ABI_CAP="Universal"
+
+          locate_universal_apk() {
+            local apk
+            local metadata
+            local output_file
+            local base_dir
+            local candidate
+
+            for dir in \
+              "app/build/outputs/apk/gms${DEVICE_CAP}${ABI_CAP}/release" \
+              "app/build/outputs/apk/gms${DEVICE}${ABI_CAP}/release" \
+              "app/build/outputs/apk/gms/${DEVICE}/${ABI}/release" \
+              "app/build/outputs/apk/gms/${DEVICE}${ABI_CAP}/release" \
+              "app/build/outputs/apk/gms/${DEVICE_CAP}${ABI_CAP}/release" \
+              "app/build/outputs/apk/${DEVICE}/${ABI}/release" \
+              "app/build/outputs/apk/${DEVICE}${ABI_CAP}/release" \
+              "app/build/outputs/apk/${DEVICE_CAP}${ABI_CAP}/release"
+            do
+              [ -d "$dir" ] || continue
+
+              apk="$(find "$dir" -maxdepth 1 -type f -name "*-unsigned.apk" | head -n 1 || true)"
+              if [ -n "${apk:-}" ] && [ -f "$apk" ]; then
+                echo "$apk"
+                return 0
+              fi
+
+              apk="$(find "$dir" -maxdepth 1 -type f -name "*.apk" ! -name "*-signed.apk" ! -name "*-unsigned-signed.apk" | head -n 1 || true)"
+              if [ -n "${apk:-}" ] && [ -f "$apk" ]; then
+                echo "$apk"
+                return 0
+              fi
+            done
+
+            metadata="$(
+              find app/build/outputs/apk -type f -name "output-metadata.json" \
+                \( \
+                  -path "*/gms${DEVICE_CAP}${ABI_CAP}/release/output-metadata.json" -o \
+                  -path "*/gms${DEVICE}${ABI_CAP}/release/output-metadata.json" -o \
+                  -path "*/gms/${DEVICE}/${ABI}/release/output-metadata.json" -o \
+                  -path "*/gms/${DEVICE}${ABI_CAP}/release/output-metadata.json" -o \
+                  -path "*/gms/${DEVICE_CAP}${ABI_CAP}/release/output-metadata.json" -o \
+                  -path "*/${DEVICE}/${ABI}/release/output-metadata.json" -o \
+                  -path "*/${DEVICE}${ABI_CAP}/release/output-metadata.json" -o \
+                  -path "*/${DEVICE_CAP}${ABI_CAP}/release/output-metadata.json" -o \
+                  -path "*/gms${DEVICE_CAP}${ABI_CAP}/*/release/output-metadata.json" -o \
+                  -path "*/gms${DEVICE}${ABI_CAP}/*/release/output-metadata.json" -o \
+                  -path "*/gms/${DEVICE}/${ABI}/*/release/output-metadata.json" -o \
+                  -path "*/gms/${DEVICE}${ABI_CAP}/*/release/output-metadata.json" -o \
+                  -path "*/gms/${DEVICE_CAP}${ABI_CAP}/*/release/output-metadata.json" -o \
+                  -path "*/${DEVICE}/${ABI}/*/release/output-metadata.json" -o \
+                  -path "*/${DEVICE}${ABI_CAP}/*/release/output-metadata.json" -o \
+                  -path "*/${DEVICE_CAP}${ABI_CAP}/*/release/output-metadata.json" \
+                \) \
+                | head -n 1 || true
+            )"
+            if [ -n "${metadata:-}" ]; then
+              output_file="$(grep -oP '"outputFile"\s*:\s*"\K[^"]+' "$metadata" | head -n 1 || true)"
+              if [ -n "${output_file:-}" ]; then
+                base_dir="$(dirname "$metadata")"
+                candidate="$base_dir/$output_file"
+                if [ -f "$candidate" ]; then
+                  echo "$candidate"
+                  return 0
+                fi
+              fi
+            fi
+
+            apk="$(find app/build/outputs/apk -type f -name "*-unsigned.apk" \
+              \( \
+                -path "*/gms${DEVICE_CAP}${ABI_CAP}/*" -o \
+                -path "*/gms${DEVICE}${ABI_CAP}/*" -o \
+                -path "*/gms/${DEVICE}/${ABI}/*" -o \
+                -path "*/gms/${DEVICE}${ABI_CAP}/*" -o \
+                -path "*/gms/${DEVICE_CAP}${ABI_CAP}/*" -o \
+                -path "*/${DEVICE}/${ABI}/*" -o \
+                -path "*/${DEVICE}${ABI_CAP}/*" -o \
+                -path "*/${DEVICE_CAP}${ABI_CAP}/*" \
+              \) | head -n 1 || true)"
+            if [ -n "${apk:-}" ] && [ -f "$apk" ]; then
+              echo "$apk"
+              return 0
+            fi
+
+            apk="$(find app/build/outputs/apk -type f -name "*.apk" ! -name "*-signed.apk" ! -name "*-unsigned-signed.apk" \
+              \( \
+                -path "*/gms${DEVICE_CAP}${ABI_CAP}/*" -o \
+                -path "*/gms${DEVICE}${ABI_CAP}/*" -o \
+                -path "*/gms/${DEVICE}/${ABI}/*" -o \
+                -path "*/gms/${DEVICE}${ABI_CAP}/*" -o \
+                -path "*/gms/${DEVICE_CAP}${ABI_CAP}/*" -o \
+                -path "*/${DEVICE}/${ABI}/*" -o \
+                -path "*/${DEVICE}${ABI_CAP}/*" -o \
+                -path "*/${DEVICE_CAP}${ABI_CAP}/*" \
+              \) | head -n 1 || true)"
+            if [ -n "${apk:-}" ] && [ -f "$apk" ]; then
+              echo "$apk"
+              return 0
+            fi
+
+            return 1
+          }
+
+          ./gradlew clean assembleGmsMobileUniversalRelease
+          APK_1="$(locate_universal_apk || true)"
+          if [ -z "${APK_1:-}" ] || [ ! -f "$APK_1" ]; then
+            echo "Could not find unsigned universal release APK (first build)."
+            echo "APK outputs:"
+            find app/build/outputs/apk -maxdepth 6 -type f -print || true
+            exit 1
+          fi
+          SHA_1="$(sha256sum "$APK_1" | awk '{print $1}')"
+          cp "$APK_1" /tmp/universal-1.apk
+
+          ./gradlew clean assembleGmsMobileUniversalRelease
+          APK_2="$(locate_universal_apk || true)"
+          if [ -z "${APK_2:-}" ] || [ ! -f "$APK_2" ]; then
+            echo "Could not find unsigned universal release APK (second build)."
+            echo "APK outputs:"
+            find app/build/outputs/apk -maxdepth 6 -type f -print || true
+            exit 1
+          fi
+          SHA_2="$(sha256sum "$APK_2" | awk '{print $1}')"
+
+          echo "sha256 #1: $SHA_1"
+          echo "sha256 #2: $SHA_2"
+          test "$SHA_1" = "$SHA_2"
+
+  build:
+    name: Build Release APKs
+    needs: [check-version]
+    # Removed '|| workflow_dispatch' so it respects the version check
+    if: needs.check-version.outputs.version_changed == 'true'
+    runs-on: ubuntu-latest
+    env:
+      VERSION_NAME_OVERRIDE: ${{ needs.check-version.outputs.new_version }}
+      VERSION_CODE_OVERRIDE: ${{ needs.check-version.outputs.version_code }}
+    strategy:
+      matrix:
+        include:
+          - device: mobile
+            distribution: gms
+            distributionName: Gms
+            deviceName: Mobile
+            abi: arm64
+          - device: mobile
+            distribution: gms
+            distributionName: Gms
+            deviceName: Mobile
+            abi: armeabi
+          - device: mobile
+            distribution: gms
+            distributionName: Gms
+            deviceName: Mobile
+            abi: x86
+          - device: mobile
+            distribution: gms
+            distributionName: Gms
+            deviceName: Mobile
+            abi: x86_64
+          - device: mobile
+            distribution: gms
+            distributionName: Gms
+            deviceName: Mobile
+            abi: universal
+          - device: tv
+            distribution: gms
+            distributionName: Gms
+            deviceName: Tv
+            abi: universal
+          - device: mobile
+            distribution: foss
+            distributionName: Foss
+            deviceName: Mobile
+            abi: universal
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
+      
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      
+      - name: Set Up Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-cleanup: on-success
+          
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Resolve variant names
+        id: variant
+        shell: bash
+        run: |
+          set -euo pipefail
+          DISTRIBUTION="${{ matrix.distribution }}"
+          DISTRIBUTION_CAP="${{ matrix.distributionName }}"
+          DEVICE="${{ matrix.device }}"
+          ABI="${{ matrix.abi }}"
+          DEVICE_CAP="${{ matrix.deviceName }}"
+          ABI_CAP="$(tr '[:lower:]' '[:upper:]' <<< "${ABI:0:1}")${ABI:1}"
+          echo "distribution=$DISTRIBUTION" >> "$GITHUB_OUTPUT"
+          echo "distribution_cap=$DISTRIBUTION_CAP" >> "$GITHUB_OUTPUT"
+          echo "device=$DEVICE" >> "$GITHUB_OUTPUT"
+          echo "abi=$ABI" >> "$GITHUB_OUTPUT"
+          echo "device_cap=$DEVICE_CAP" >> "$GITHUB_OUTPUT"
+          echo "abi_cap=$ABI_CAP" >> "$GITHUB_OUTPUT"
+          echo "gradle_task=assemble${DISTRIBUTION_CAP}${DEVICE_CAP}${ABI_CAP}Release" >> "$GITHUB_OUTPUT"
+          echo "artifact_name=app-${DISTRIBUTION}-${DEVICE}-${ABI}-release" >> "$GITHUB_OUTPUT"
+          echo "apk_name=app-${DISTRIBUTION}-${DEVICE}-${ABI}-release.apk" >> "$GITHUB_OUTPUT"
+ 
+      - name: Build Release APK
+        shell: bash
+        run: |
+          set -euo pipefail
+          GRADLE_TASK="${{ steps.variant.outputs.gradle_task }}"
+          ABI="${{ matrix.abi }}"
+
+          if [ "$ABI" = "armeabi" ] || [ "$ABI" = "x86" ]; then
+            ./gradlew "$GRADLE_TASK" 2>&1 | python3 -c "import re,sys;p=re.compile(r'^(WARNING: )?\[CXX5202\] This app only has 32-bit \[(armeabi-v7a|x86)\] native libraries\. Beginning August 1, 2019 Google Play store requires that all apps that include native libraries must provide 64-bit versions\. For more information, visit https://g\.co/64-bit-requirement\$');[sys.stdout.write(l) for l in sys.stdin if not p.match(l.rstrip())]"
+          else
+            ./gradlew "$GRADLE_TASK"
+          fi
+        env:
+          PULL_REQUEST: 'false'
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          LASTFM_API_KEY: ${{ secrets.LASTFM_API_KEY }}
+          LASTFM_SECRET: ${{ secrets.LASTFM_SECRET }}
+          API_BEARER_TOKEN: ${{ secrets.API_BEARER_TOKEN }}
+          TOGETHER_BEARER_TOKEN: ${{ secrets.TOGETHER_BEARER_TOKEN }}
+          CANVAS_BEARER_TOKEN: ${{ secrets.CANVAS_BEARER_TOKEN }}
+          EXTRACTOR_BEARER: ${{ secrets.EXTRACTOR_BEARER }}
+          START_IO_APP_ID: ${{ secrets.START_IO_APP_ID }}
+          # Public base URL of the community Source Pool site. Repo variable (not a secret) so the
+          # app auto-discovers health-checked Tidal/Qobuz instances. Blank disables discovery.
+          SOURCE_PROVIDER_URL: ${{ vars.SOURCE_PROVIDER_URL }}
+          # Per-app read key for the pool (secret). Blank is fine while the pool runs unenforced.
+          SOURCE_PROVIDER_KEY: ${{ secrets.SOURCE_PROVIDER_KEY }}
+          # End-to-end decryption key for encrypted pool credentials (secret). Blank if unencrypted.
+          POOL_CLIENT_KEY: ${{ secrets.POOL_CLIENT_KEY }}
+          # Telegram (TDLib) credentials from https://my.telegram.org/apps. Optional: when unset the
+          # build falls back to Telegram Desktop's public api_id, which violates Telegram's ToS.
+          TELEGRAM_API_ID: ${{ secrets.TELEGRAM_API_ID }}
+          TELEGRAM_API_HASH: ${{ secrets.TELEGRAM_API_HASH }}
+
+      - name: Resolve release output directory
+        id: release_dir
+        shell: bash
+        run: |
+          set -euo pipefail
+          DISTRIBUTION="${{ steps.variant.outputs.distribution }}"
+          DEVICE="${{ steps.variant.outputs.device }}"
+          ABI="${{ steps.variant.outputs.abi }}"
+          DEVICE_CAP="${{ steps.variant.outputs.device_cap }}"
+          ABI_CAP="${{ steps.variant.outputs.abi_cap }}"
+          CANDIDATES=(
+            "app/build/outputs/apk/${DISTRIBUTION}${DEVICE_CAP}${ABI_CAP}/release"
+            "app/build/outputs/apk/${DISTRIBUTION}${DEVICE}${ABI_CAP}/release"
+            "app/build/outputs/apk/${DISTRIBUTION}/${DEVICE}/${ABI}/release"
+            "app/build/outputs/apk/${DISTRIBUTION}/${DEVICE}${ABI_CAP}/release"
+            "app/build/outputs/apk/${DISTRIBUTION}/${DEVICE_CAP}${ABI_CAP}/release"
+            "app/build/outputs/apk/gms${DEVICE_CAP}${ABI_CAP}/release"
+            "app/build/outputs/apk/gms${DEVICE}${ABI_CAP}/release"
+            "app/build/outputs/apk/gms/${DEVICE}/${ABI}/release"
+            "app/build/outputs/apk/gms/${DEVICE}${ABI_CAP}/release"
+            "app/build/outputs/apk/gms/${DEVICE_CAP}${ABI_CAP}/release"
+            "app/build/outputs/apk/${DEVICE}/${ABI}/release"
+            "app/build/outputs/apk/${DEVICE}${ABI_CAP}/release"
+            "app/build/outputs/apk/${DEVICE_CAP}${ABI_CAP}/release"
+            "app/build/outputs/apk/${ABI}/${DEVICE}/release"
+          )
+          for d in "${CANDIDATES[@]}"; do
+            if [ -d "$d" ]; then
+              echo "release_dir=$d" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+
+          FOUND_METADATA="$(
+            find app/build/outputs/apk -type f -name "output-metadata.json" \
+              \( \
+                -path "*/${DISTRIBUTION}/${DEVICE}/${ABI}/release/output-metadata.json" -o \
+                -path "*/${DISTRIBUTION}${DEVICE}${ABI_CAP}/release/output-metadata.json" -o \
+                -path "*/${DISTRIBUTION}${DEVICE_CAP}${ABI_CAP}/release/output-metadata.json" -o \
+                -path "*/${DISTRIBUTION}/${DEVICE}/${ABI}/*/release/output-metadata.json" -o \
+                -path "*/${DISTRIBUTION}${DEVICE}${ABI_CAP}/*/release/output-metadata.json" -o \
+                -path "*/${DISTRIBUTION}${DEVICE_CAP}${ABI_CAP}/*/release/output-metadata.json" -o \
+                -path "*/${DEVICE}/${ABI}/release/output-metadata.json" -o \
+                -path "*/${DEVICE}${ABI_CAP}/release/output-metadata.json" -o \
+                -path "*/${DEVICE_CAP}${ABI_CAP}/release/output-metadata.json" -o \
+                -path "*/${ABI}/${DEVICE}/release/output-metadata.json" -o \
+                -path "*/${DEVICE}/${ABI}/*/release/output-metadata.json" -o \
+                -path "*/${DEVICE}${ABI_CAP}/*/release/output-metadata.json" -o \
+                -path "*/${DEVICE_CAP}${ABI_CAP}/*/release/output-metadata.json" \
+              \) \
+              | head -n 1 || true
+          )"
+          if [ -n "${FOUND_METADATA:-}" ]; then
+            echo "release_dir=$(dirname "$FOUND_METADATA")" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Could not resolve APK release output directory for DISTRIBUTION=$DISTRIBUTION DEVICE=$DEVICE ABI=$ABI"
+          find app/build/outputs/apk -maxdepth 8 -type d -print || true
+          exit 1
+
+      - name: Prepare signing key
+        id: signing
+        shell: bash
+        env:
+          KEYSTORE: ${{ secrets.KEYSTORE }}
+        run: |
+          set -euo pipefail
+          if [ -n "$KEYSTORE" ]; then
+            # Real release keystore is configured (e.g. upstream); use it as-is.
+            echo "mode=secret" >> "$GITHUB_OUTPUT"
+          else
+            # No KEYSTORE secret (expected on forks): sign with the FIXED, committed
+            # keystore so every release APK across all ABIs shares one stable signature
+            # and installs/updates over the previous one. Debug-grade key: fine for
+            # self-distribution, NOT for the Play Store.
+            FIXED_KEYSTORE="$GITHUB_WORKSPACE/app/persistent-debug.keystore"
+            if [ ! -f "$FIXED_KEYSTORE" ]; then
+              echo "::error::Fixed keystore not found at $FIXED_KEYSTORE"
+              exit 1
+            fi
+            echo "::notice::No KEYSTORE secret configured. Signing with the fixed committed keystore for stable, updatable signatures across all builds and ABIs."
+            {
+              echo "mode=test"
+              echo "signing_key=$(base64 -w0 "$FIXED_KEYSTORE")"
+              echo "alias=androiddebugkey"
+              echo "store_pass=android"
+              echo "key_pass=android"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Sign APK (release keystore)
+        if: steps.signing.outputs.mode == 'secret'
+        uses: ilharp/sign-android-release@v2.0.0
+        with:
+          releaseDir: ${{ steps.release_dir.outputs.release_dir }}/
+          signingKey: ${{ secrets.KEYSTORE }}
+          keyAlias: ${{ secrets.KEY_ALIAS }}
+          keyStorePassword: ${{ secrets.KEYSTORE_PASSWORD }}
+          keyPassword: ${{ secrets.KEY_PASSWORD }}
+          buildToolsVersion: 35.0.0
+
+      - name: Sign APK (fixed keystore)
+        if: steps.signing.outputs.mode == 'test'
+        uses: ilharp/sign-android-release@v2.0.0
+        with:
+          releaseDir: ${{ steps.release_dir.outputs.release_dir }}/
+          signingKey: ${{ steps.signing.outputs.signing_key }}
+          keyAlias: ${{ steps.signing.outputs.alias }}
+          keyStorePassword: ${{ steps.signing.outputs.store_pass }}
+          keyPassword: ${{ steps.signing.outputs.key_pass }}
+          buildToolsVersion: 35.0.0
+      
+      - name: Move and rename APK
+        shell: bash
+        run: |
+          set -euo pipefail
+          RELEASE_DIR="${{ steps.release_dir.outputs.release_dir }}"
+          mkdir -p "$RELEASE_DIR/out"
+          mapfile -t SIGNED_APKS < <(
+            find "$RELEASE_DIR" -maxdepth 1 -type f \
+              \( -name "*-signed.apk" -o -name "*-unsigned-signed.apk" \)
+          )
+          if [ "${#SIGNED_APKS[@]}" -ne 1 ]; then
+            echo "Expected exactly one signed APK in $RELEASE_DIR, found ${#SIGNED_APKS[@]}"
+            find "$RELEASE_DIR" -maxdepth 2 -type f -print || true
+            exit 1
+          fi
+          APK="${SIGNED_APKS[0]}"
+          mv "$APK" "$RELEASE_DIR/out/${{ steps.variant.outputs.apk_name }}"
+  
+      - name: Upload APK
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ steps.variant.outputs.artifact_name }}
+          path: ${{ steps.release_dir.outputs.release_dir }}/out/${{ steps.variant.outputs.apk_name }}
+
+  create-release:
+    needs: [check-version, build]
+    if: needs.check-version.outputs.version_changed == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Download all APKs
+        uses: actions/download-artifact@v8
+        with:
+          path: downloaded_artifacts/
+
+      - name: Resolve changelog range
+        id: changelog_range
+        shell: bash
+        run: |
+          LAST_TAG="$(git describe --tags --abbrev=0 --match "v*" 2>/dev/null || true)"
+          if [ -n "$LAST_TAG" ]; then
+            FROM_REF="$LAST_TAG"
+          else
+            FROM_REF="$(git rev-list --max-parents=0 HEAD | tail -n 1)"
+          fi
+
+          echo "from_ref=$FROM_REF" >> "$GITHUB_OUTPUT"
+          echo "to_ref=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+
+      - name: Build Changelog
+        id: build_changelog
+        uses: mikepenz/release-changelog-builder-action@v6
+        with:
+          mode: "COMMIT"
+          fromTag: ${{ steps.changelog_range.outputs.from_ref }}
+          toTag: ${{ steps.changelog_range.outputs.to_ref }}
+          configurationJson: |
+            {
+              "template": "# Changelog\n\n#{{CHANGELOG}}\n\n<details>\n<summary>Other changes</summary>\n\n#{{UNCATEGORIZED}}\n</details>\n",
+              "pr_template": "- #{{TITLE}} — by @#{{AUTHOR}}",
+              "categories": [
+                { "title": "## Features", "labels": ["feat", "feature"] },
+                { "title": "## Fixes", "labels": ["fix", "bug"] },
+                { "title": "## Performance", "labels": ["perf"] },
+                { "title": "## Refactors", "labels": ["refactor"] },
+                { "title": "## Documentation", "labels": ["docs"] },
+                { "title": "## Build / CI", "labels": ["build", "ci"] }
+              ],
+              "label_extractor": [
+                {
+                  "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\\([\\w\\-\\.]+\\))?(!)?:\\s+.*$",
+                  "on_property": "title",
+                  "target": "$1"
+                }
+              ]
+            }
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create Release
+        # Prefer a PAT (needed upstream so the release triggers downstream workflows), but fall
+        # back to the built-in GITHUB_TOKEN so forks without a RELEASE_PAT secret can still publish.
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+        run: |
+          MOBILE_UNIVERSAL_APK=$(find downloaded_artifacts/app-gms-mobile-universal-release -name "*.apk" | head -n 1)
+          OTHER_APKS=$(find downloaded_artifacts -path "*/app-*-release/*.apk" ! -path "*/app-gms-mobile-universal-release/*")
+
+          # Release notes are ONLY the generated changelog.
+          #
+          # There used to be a hardcoded "What's new 🎵" block here, written inside a quoted
+          # heredoc (<<'NOTES') so no expansion happened and it was emitted byte-identical on
+          # every release. Its bullets described one specific past release -- "Fixed app icon on
+          # home screen", "Smoother animations" -- and then kept claiming them on every later
+          # build, while pushing the real per-release list further down the page. That is why
+          # consecutive releases read as having the same changelog: the top section literally was
+          # the same text every time.
+          #
+          # Anything newsworthy belongs in a commit subject, where build_changelog picks it up and
+          # files it under Features/Fixes/Performance automatically.
+          cat > release_notes.md <<EOF
+          ${{ steps.build_changelog.outputs.changelog }}
+          EOF
+
+          # With the static block gone the changelog is the only content, so an empty generator
+          # result (bad tag range, nothing matched) would publish blank notes. Fall back to a
+          # compare link instead.
+          if [ -z "$(tr -d '[:space:]' < release_notes.md)" ]; then
+            PREV_TAG="${{ steps.changelog_range.outputs.from_ref }}"
+            {
+              echo "# Changelog"
+              echo
+              echo "No categorised commits were found for this range."
+              if [ -n "$PREV_TAG" ]; then
+                echo
+                echo "Full diff: https://github.com/${{ github.repository }}/compare/${PREV_TAG}...v${{ needs.check-version.outputs.new_version }}"
+              fi
+            } > release_notes.md
+          fi
+
+          gh release create "v${{ needs.check-version.outputs.new_version }}" \
+            --target "${{ github.sha }}" \
+            --title "${{ needs.check-version.outputs.new_version }}" \
+            --notes-file release_notes.md \
+            "$MOBILE_UNIVERSAL_APK" \
+            $OTHER_APKS


### PR DESCRIPTION
## Why there have been no stable releases

`a3b049da6` ("prune unused workflows") deleted `.github/workflows/release.yml` alongside `header.yml` and `notify_user.yml`. The other two were genuinely unused — `notify_user.yml` backed a `notifyUser` job that the same commit removed from `build.yml`.

`release.yml` was not unused: it was the only thing that published a stable GitHub release. Since then, merging a PR into `main` has only run **Build APKs**, which builds and pushes to Telegram but creates no release. Hence the newest stable is still `v14.0.5197` (Jul 25) while `main` has moved well past it.

## Why every changelog looked the same

Notes were assembled from a **quoted** heredoc:

```
cat > release_notes.md <<'NOTES'
## What's new 🎵
- 🎧 **Qobuz & Tidal integration** — ...
- 🖼️ **Fixed app icon on home screen** — ...
- ✨ **Smoother animations** — ...
- 🔧 **Various bug fixes and stability improvements** ...
NOTES
```

Quoting means no expansion, so this was emitted byte-identical on every release. It described one specific past build and kept re-advertising those changes afterwards, while pushing the real generated changelog further down the page. The generator underneath was always working correctly.

Notes are now **only** the generated changelog, which already splits commits into Features / Fixes / Performance and genuinely differs per release. Anything newsworthy goes in a commit subject and is picked up automatically.

## Also

- Since the changelog is now the sole content, an empty generator result would publish blank notes — added a fallback to a compare link.
- Restored from `main`'s own pre-deletion copy, **not** the `anxfix` variant, which additionally drops `TELEGRAM_API_ID`/`_HASH` and adds reproducibility diffing.

## Notes before merging

- Version is still `MAJOR_MINOR.<commit count>` and skips when the tag exists, so this **cannot** collide with `v14.0.5197`.
- The first release after merging spans everything since Jul 25, so its changelog will be long. Subsequent ones are normal.
- `build.yml` (push to `main`+`dev`) and `release.yml` (push to `main`) both build on a merge to `main`. That duplication is pre-existing, restored as-is rather than changed here.