### PR TITLE
fix(updater): point in-app updates at this fork, not upstream

### DIFF
--- a/.github/workflows/mirror-4nx3b.yml
+++ b/.github/workflows/mirror-4nx3b.yml
@@ -247,6 +247,27 @@ jobs:
           rm -rf .github
           cp -a /tmp/keep_github .github
 
+          # Repoint the in-app updater at this fork.
+          #
+          # Upstream hardcodes their own repo in Updater.OWNER, correctly for them. Mirroring it
+          # verbatim ships an app that offers users an APK signed with upstream's keystore, and
+          # since applicationId is identical across ArchiveTune forks Android rejects that install
+          # as INSTALL_FAILED_UPDATE_INCOMPATIBLE -- the download succeeds and the install fails,
+          # so it looks like a broken updater. Preserving .github/ is not enough; this line is app
+          # source, and the mirror has already reverted it once.
+          UPDATER=app/src/main/kotlin/moe/rukamori/archivetune/utils/Updater.kt
+          if [ ! -f "$UPDATER" ]; then
+            echo "::error::${UPDATER} not found -- upstream moved it. Repoint Updater.OWNER before mirroring."
+            exit 1
+          fi
+          sed -i -E 's|^(\s*private const val OWNER = ")[^"]+(")|\1'"${GITHUB_REPOSITORY}"'\2|' "$UPDATER"
+          if ! grep -q "private const val OWNER = \"${GITHUB_REPOSITORY}\"" "$UPDATER"; then
+            echo "::error::Failed to repoint Updater.OWNER -- the declaration changed shape upstream."
+            echo "Found: $(grep -n 'const val OWNER' "$UPDATER" || echo '<none>')"
+            exit 1
+          fi
+          echo "Updater.OWNER repointed to ${GITHUB_REPOSITORY}."
+
           git add -A
 
           # `git add -A` must not have re-flattened the gitlinks staged above. Assert against the

--- a/app/src/main/kotlin/moe/rukamori/archivetune/utils/Updater.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/utils/Updater.kt
@@ -56,7 +56,7 @@ object Updater {
     private val client = HttpClient()
     private const val ReleaseCacheCheckIntervalMs: Long = 6 * 60 * 60 * 1000L
     private const val CanaryCacheCheckIntervalMs: Long = 15 * 60 * 1000L
-    private const val OWNER = "4nx3b/ArchiveTune"
+    private const val OWNER = "vossgraves/ArchiveTune"
     private const val StableReleaseBaseUrl = "https://github.com/$OWNER/releases"
     private const val CanaryReleaseBaseUrl =
         "https://github.com/$OWNER/releases"


### PR DESCRIPTION
Users on this fork cannot update in-app. `Updater.OWNER` is `4nx3b/ArchiveTune`, so the updater checks **their** releases and downloads **their** APKs.

Both repos ship `applicationId = moe.rukamori.archivetune` but sign with different keystores, and Android will not install over a package whose signing certificate differs. The update is offered, the download succeeds, and the install is rejected with `INSTALL_FAILED_UPDATE_INCOMPATIBLE` ("App not installed") — so it looks like a broken updater rather than a mismatched source. Canary had the same issue via `nightly.link/$OWNER`.

### Changes
- `Updater.OWNER` -> `vossgraves/ArchiveTune`. Stable, canary, and workflow-artifact URLs all derive from it.
- `mirror-4nx3b.yml` now repoints `OWNER` after laying down upstream's tree. Without this the next sync silently restores their value, since only `.github/` was preserved. It hard-fails if the declaration moves or changes shape.

### Notes
- No coverage is lost: the mirror republishes their stable releases here under their exact tag, signed by this fork.
- Release asset names already match on both sides (`app-gms-mobile-universal-release.apk` etc.), so no artifact-name change is needed.
- About-screen attribution to @4nx3b is untouched.